### PR TITLE
feat: user profile page — name, birth year, sex, height (#105)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -109,7 +109,7 @@ users
   email           TEXT UNIQUE
   hashed_password TEXT NOT NULL         -- bcrypt hash
   display_name    TEXT
-  date_of_birth   TEXT                  -- ISO date string; age calculated dynamically
+  birth_year      INTEGER               -- year only (not full DOB); age calculated as current_year - birth_year
   sex             TEXT                  -- "male" | "female" | "other"
   height_cm       REAL
   is_active       BOOLEAN NOT NULL DEFAULT 1
@@ -278,6 +278,14 @@ docker compose -f docker-compose.prod.yml up -d
 In production, only nginx (port 80) is exposed to the host. The backend runs on an internal Docker network — nginx proxies `/api/` requests to it.
 
 On every container start, `entrypoint.sh` runs `alembic upgrade head` before starting uvicorn, so database migrations apply automatically on deploy.
+
+## Design decisions
+
+### `birth_year` instead of `date_of_birth`
+
+The user model stores `birth_year` (integer) rather than a full date-of-birth. Full DOB is PII; birth year alone is not identifying on its own. Age is computed dynamically (`current_year - birth_year`) so it never goes stale. The ±1-year imprecision (birthday not yet passed this calendar year) is within the noise margin of the BIA formulae that consume it.
+
+Symmetric encryption of the full DOB was considered but deferred — it adds key-management complexity that is disproportionate to the threat model of a self-hosted, Tailscale-only app. This can be revisited in the M15 GDPR & data-security milestone if the threat model changes.
 
 ## Hosting & access
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -43,6 +43,8 @@ All tests live in `backend/tests/`. The suite uses a single in-memory SQLite dat
 | `test_measurements.py` | Body measurement CRUD, auth enforcement, full BIA formula application with impedance inputs |
 | `test_progress.py` | Muscle balance, `epley_1rm` unit tests, strength progression (structure + daily best), volume over time, consistency heatmap, personal records |
 | `test_sessions.py` | Full workout session flow: start → log sets → end → list → get logs; edge cases (unknown session, already ended, 404) |
+| `test_isolation.py` | Per-user data isolation: user B cannot read user A's sessions, cardio, or measurements |
+| `test_profile.py` | GET /api/profile structure and auth, PATCH updates (display_name, birth_year, sex, height_cm), unknown fields ignored, BIA falls back to profile height |
 | `test_stats.py` | Home stats structure, streak calculation (unit + UTC correctness), week bounds (UTC correctness) |
 
 ## conftest.py

--- a/backend/alembic/versions/c4a7b2e5f1d9_merge_heads_rename_dob_to_birth_year.py
+++ b/backend/alembic/versions/c4a7b2e5f1d9_merge_heads_rename_dob_to_birth_year.py
@@ -1,0 +1,28 @@
+"""merge heads and rename date_of_birth to birth_year
+
+Revision ID: c4a7b2e5f1d9
+Revises: b3d7f9e1c4a2, f6b436bab21e
+Create Date: 2026-07-05
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c4a7b2e5f1d9"
+down_revision: Union[str, Sequence[str], None] = ("b3d7f9e1c4a2", "f6b436bab21e")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.drop_column("date_of_birth")
+        batch_op.add_column(sa.Column("birth_year", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.drop_column("birth_year")
+        batch_op.add_column(sa.Column("date_of_birth", sa.String(), nullable=True))

--- a/backend/main.py
+++ b/backend/main.py
@@ -12,6 +12,7 @@ from routers import cardio as cardio_router
 from routers import exercises as exercises_router
 from routers import logs as logs_router
 from routers import measurements as measurements_router
+from routers import profile as profile_router
 from routers import progress as progress_router
 from routers import sessions as sessions_router
 from routers import stats as stats_router
@@ -59,6 +60,7 @@ app.include_router(logs_router.router)
 app.include_router(progress_router.router)
 app.include_router(measurements_router.router)
 app.include_router(cardio_router.router)
+app.include_router(profile_router.router)
 app.include_router(stats_router.router)
 
 

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import datetime
 
 from sqlalchemy import Boolean, Float, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
@@ -14,7 +14,7 @@ class User(Base):
     email: Mapped[str | None] = mapped_column(String, unique=True)
     hashed_password: Mapped[str] = mapped_column(String, nullable=False)
     display_name: Mapped[str | None] = mapped_column(String)
-    date_of_birth: Mapped[date | None] = mapped_column(String)  # stored as ISO string
+    birth_year: Mapped[int | None] = mapped_column(Integer)
     sex: Mapped[str | None] = mapped_column(String)  # 'male' | 'female' | 'other'
     height_cm: Mapped[float | None] = mapped_column(Float)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)

--- a/backend/routers/measurements.py
+++ b/backend/routers/measurements.py
@@ -14,6 +14,8 @@ from models.user import User
 
 router = APIRouter(prefix="/api/measurements", tags=["measurements"])
 
+_SEX_MAP = {"male": 1, "female": 0}
+
 
 class _MeasurementFields(BaseModel):
     """All stored measurement fields — shared by input and output schemas."""
@@ -126,12 +128,31 @@ def log_measurement(
     current_user: User = Depends(get_current_user),
 ):
     data = body.model_dump()
-    age = data.pop("user_age") or int(os.getenv("SCALE_AGE", "0"))
-    sex_val = data.pop("user_sex")
-    sex = sex_val if sex_val is not None else int(os.getenv("SCALE_SEX", "1"))
+    age_from_request = data.pop("user_age")
+    sex_from_request = data.pop("user_sex")
     data["recorded_at"] = data["recorded_at"] or datetime.now(timezone.utc)
     data["user_id"] = current_user.id
     measurement = BodyMeasurement(**data)
+
+    # Profile fallback for height
+    if measurement.height_cm is None and current_user.height_cm:
+        measurement.height_cm = current_user.height_cm
+
+    # Age: request → profile birth_year → env
+    if age_from_request:
+        age = age_from_request
+    elif current_user.birth_year:
+        age = datetime.now(timezone.utc).year - current_user.birth_year
+    else:
+        age = int(os.getenv("SCALE_AGE", "0"))
+
+    # Sex: request → profile sex → env
+    if sex_from_request is not None:
+        sex = sex_from_request
+    elif current_user.sex in _SEX_MAP:
+        sex = _SEX_MAP[current_user.sex]
+    else:
+        sex = int(os.getenv("SCALE_SEX", "1"))
     db.add(measurement)
     db.commit()
     db.refresh(measurement)

--- a/backend/routers/profile.py
+++ b/backend/routers/profile.py
@@ -1,0 +1,45 @@
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy.orm import Session
+
+from auth import get_current_user
+from database import get_db
+from models.user import User
+
+router = APIRouter(prefix="/api/profile", tags=["profile"])
+
+
+class ProfileOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    username: str
+    email: str | None
+    display_name: str | None
+    birth_year: int | None
+    sex: str | None
+    height_cm: float | None
+
+
+class ProfilePatch(BaseModel):
+    display_name: str | None = None
+    birth_year: int | None = None
+    sex: str | None = None
+    height_cm: float | None = None
+
+
+@router.get("", response_model=ProfileOut)
+def get_profile(current_user: User = Depends(get_current_user)):
+    return current_user
+
+
+@router.patch("", response_model=ProfileOut)
+def patch_profile(
+    body: ProfilePatch,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    for field, value in body.model_dump(exclude_unset=True).items():
+        setattr(current_user, field, value)
+    db.commit()
+    db.refresh(current_user)
+    return current_user

--- a/backend/tests/test_profile.py
+++ b/backend/tests/test_profile.py
@@ -1,0 +1,105 @@
+from fastapi.testclient import TestClient
+
+
+def _token(client: TestClient) -> str:
+    return client.post(
+        "/api/auth/login", json={"username": "testuser", "password": "testpass"}
+    ).json()["access_token"]
+
+
+def _auth(client: TestClient) -> dict:
+    return {"Authorization": f"Bearer {_token(client)}"}
+
+
+# ── GET /api/profile ──────────────────────────────────────────────────────────
+
+
+def test_profile_returns_correct_structure(client: TestClient):
+    resp = client.get("/api/profile", headers=_auth(client))
+    assert resp.status_code == 200
+    data = resp.json()
+    for key in ("username", "display_name", "birth_year", "sex", "height_cm", "email"):
+        assert key in data
+
+
+def test_profile_requires_auth(client: TestClient):
+    from fastapi.testclient import TestClient as TC
+
+    from main import app
+
+    c = TC(app)
+    assert c.get("/api/profile").status_code == 401
+
+
+# ── PATCH /api/profile ────────────────────────────────────────────────────────
+
+
+def test_patch_profile_updates_display_name(client: TestClient):
+    resp = client.patch(
+        "/api/profile", json={"display_name": "Dave Test"}, headers=_auth(client)
+    )
+    assert resp.status_code == 200
+    assert resp.json()["display_name"] == "Dave Test"
+
+
+def test_patch_profile_updates_height(client: TestClient):
+    resp = client.patch(
+        "/api/profile", json={"height_cm": 182.0}, headers=_auth(client)
+    )
+    assert resp.status_code == 200
+    assert resp.json()["height_cm"] == 182.0
+
+
+def test_patch_profile_updates_birth_year(client: TestClient):
+    resp = client.patch(
+        "/api/profile", json={"birth_year": 1990}, headers=_auth(client)
+    )
+    assert resp.status_code == 200
+    assert resp.json()["birth_year"] == 1990
+
+
+def test_patch_profile_updates_sex(client: TestClient):
+    resp = client.patch("/api/profile", json={"sex": "male"}, headers=_auth(client))
+    assert resp.status_code == 200
+    assert resp.json()["sex"] == "male"
+
+
+def test_patch_profile_ignores_unknown_fields(client: TestClient):
+    resp = client.patch(
+        "/api/profile", json={"nonexistent_field": "value"}, headers=_auth(client)
+    )
+    assert resp.status_code == 200
+
+
+# ── Profile fields used as BIA fallback ───────────────────────────────────────
+
+
+def test_bia_uses_profile_height_when_not_in_request(client: TestClient):
+    """Set height_cm in profile; BIA payload without height_cm must still run formulae."""
+    headers = _auth(client)
+    client.patch(
+        "/api/profile",
+        json={"height_cm": 180.0, "birth_year": 1996, "sex": "male"},
+        headers=headers,
+    )
+
+    resp = client.post(
+        "/api/measurements",
+        json={
+            "weight_kg": 80.0,
+            "body_fat_pct": 18.2,
+            "ra_z20": 312.5,
+            "la_z20": 308.0,
+            "rl_z20": 210.0,
+            "ll_z20": 208.5,
+            "trunk_z20": 42.0,
+            "ra_z100": 290.0,
+            "la_z100": 287.0,
+            "rl_z100": 195.0,
+            "ll_z100": 193.0,
+            "trunk_z100": 38.0,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201
+    assert resp.json()["bmi"] is not None


### PR DESCRIPTION
Closes #105

## What changed

- `GET /api/profile` — returns username, email, display_name, birth_year, sex, height_cm for the authenticated user
- `PATCH /api/profile` — updates any subset of display_name, birth_year, sex, height_cm; unknown fields are silently ignored
- `routers/measurements.py` — profile fields now serve as fallback for BIA formula inputs: height_cm → profile height, age derived from birth_year, sex mapped from profile sex string; env vars remain the final fallback
- `models/user.py` — date_of_birth (TEXT) replaced with birth_year (INTEGER); full DOB is PII, birth year is not
- Migration c4a7b2e5f1d9 — merges the two-head split (b3d7f9e1c4a2 + f6b436bab21e) and drops date_of_birth / adds birth_year in a single batch operation (SQLite-compatible)
- ARCHITECTURE.md — schema updated, new Design Decisions section documents the birth_year rationale and defers encryption to M15
- TESTING.md — test_isolation.py and test_profile.py added to the test table

## Test plan

- [ ] 105 tests pass, 0 warnings
- [ ] `GET /api/profile` returns 401 without token
- [ ] `PATCH /api/profile` with height_cm set; subsequent BIA measurement without height_cm in request body still computes bmi
- [ ] `alembic heads` shows single head c4a7b2e5f1d9