### PR TITLE
feat: password change in settings (#106)

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
-from auth import create_access_token
+from auth import create_access_token, get_current_user
 from database import get_db
 from models.user import User
 
@@ -73,6 +73,27 @@ def register(body: RegisterRequest, db: Session = Depends(get_db)):
     db.commit()
     db.refresh(user)
     return TokenResponse(access_token=create_access_token(user.id))
+
+
+class ChangePasswordRequest(BaseModel):
+    current_password: str
+    new_password: str = Field(min_length=8)
+
+
+@router.post("/change-password", status_code=status.HTTP_200_OK)
+def change_password(
+    body: ChangePasswordRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    if not _verify_password(body.current_password, current_user.hashed_password):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Current password is incorrect",
+        )
+    current_user.hashed_password = _hash_password(body.new_password)
+    db.commit()
+    return {"detail": "Password updated"}
 
 
 @router.post("/login", response_model=TokenResponse)

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,6 +1,10 @@
+from datetime import datetime, timezone
+
 import bcrypt
 from fastapi.testclient import TestClient
 
+from database import SessionLocal
+from models.user import User
 from routers.auth import _verify_password
 
 # ── Unit tests ────────────────────────────────────────────────────────────────
@@ -108,3 +112,88 @@ def test_register_accepts_minimum_length_password(client: TestClient):
         "/api/auth/register", json={"username": "newuser", "password": "12345678"}
     )
     assert resp.status_code == 409
+
+
+# ── Change password (Issue #106) ──────────────────────────────────────────────
+
+
+def _make_user(username: str, password: str) -> None:
+    db = SessionLocal()
+    hashed = bcrypt.hashpw(password.encode(), bcrypt.gensalt(rounds=4)).decode()
+    db.add(
+        User(
+            username=username,
+            hashed_password=hashed,
+            is_active=True,
+            is_admin=False,
+            created_at=datetime.now(timezone.utc),
+        )
+    )
+    db.commit()
+    db.close()
+
+
+def _login(client: TestClient, username: str, password: str) -> dict:
+    token = client.post(
+        "/api/auth/login", json={"username": username, "password": password}
+    ).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_change_password_requires_auth(client: TestClient):
+    resp = client.post(
+        "/api/auth/change-password",
+        json={"current_password": "testpass", "new_password": "newpass1234"},
+    )
+    assert resp.status_code == 401
+
+
+def test_change_password_rejects_wrong_current(client: TestClient):
+    resp = client.post(
+        "/api/auth/change-password",
+        json={"current_password": "wrongpassword", "new_password": "newpass1234"},
+        headers=_login(client, "testuser", "testpass"),
+    )
+    assert resp.status_code == 400
+
+
+def test_change_password_rejects_short_new_password(client: TestClient):
+    resp = client.post(
+        "/api/auth/change-password",
+        json={"current_password": "testpass", "new_password": "short"},
+        headers=_login(client, "testuser", "testpass"),
+    )
+    assert resp.status_code == 422
+
+
+def test_change_password_success(client: TestClient):
+    _make_user("pw_change_user", "oldpass1234")
+    resp = client.post(
+        "/api/auth/change-password",
+        json={"current_password": "oldpass1234", "new_password": "newpass5678"},
+        headers=_login(client, "pw_change_user", "oldpass1234"),
+    )
+    assert resp.status_code == 200
+    assert (
+        client.post(
+            "/api/auth/login",
+            json={"username": "pw_change_user", "password": "newpass5678"},
+        ).status_code
+        == 200
+    )
+
+
+def test_change_password_old_password_rejected_after_change(client: TestClient):
+    _make_user("pw_old_user", "oldpass1234")
+    client.post(
+        "/api/auth/change-password",
+        json={"current_password": "oldpass1234", "new_password": "newpass5678"},
+        headers=_login(client, "pw_old_user", "oldpass1234"),
+    )
+    assert (
+        client.post(
+            "/api/auth/login",
+            json={"username": "pw_old_user", "password": "oldpass1234"},
+        ).status_code
+        == 401
+    )


### PR DESCRIPTION
Closes #106

## What changed

- `POST /api/auth/change-password` — authenticated endpoint; verifies current password with bcrypt before accepting the new one, then hashes and stores it
- `ChangePasswordRequest` schema with `min_length=8` on new_password — same constraint as registration
- Returns 400 if current password is incorrect, 422 if new password is too short, 401 without a token

## Test plan

- [ ] 110 tests pass, 0 warnings
- [ ] `POST /api/auth/change-password` without token → 401
- [ ] Wrong current password → 400
- [ ] New password under 8 chars → 422
- [ ] Successful change → can login with new password, old password returns 401