### PR TITLE
feat: admin user management — list, invite, disable, delete (#107)

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -43,6 +43,7 @@ All tests live in `backend/tests/`. The suite uses a single in-memory SQLite dat
 | `test_measurements.py` | Body measurement CRUD, auth enforcement, full BIA formula application with impedance inputs |
 | `test_progress.py` | Muscle balance, `epley_1rm` unit tests, strength progression (structure + daily best), volume over time, consistency heatmap, personal records |
 | `test_sessions.py` | Full workout session flow: start → log sets → end → list → get logs; edge cases (unknown session, already ended, 404) |
+| `test_admin.py` | Admin user management: list users, create, disable/enable, delete (with data cascade); 403 for non-admins, self-disable/delete blocked |
 | `test_isolation.py` | Per-user data isolation: user B cannot read user A's sessions, cardio, or measurements |
 | `test_profile.py` | GET /api/profile structure and auth, PATCH updates (display_name, birth_year, sex, height_cm), unknown fields ignored, BIA falls back to profile height |
 | `test_stats.py` | Home stats structure, streak calculation (unit + UTC correctness), week bounds (UTC correctness) |

--- a/backend/main.py
+++ b/backend/main.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from database import SessionLocal
+from routers import admin as admin_router
 from routers import auth as auth_router
 from routers import cardio as cardio_router
 from routers import exercises as exercises_router
@@ -53,6 +54,7 @@ app.add_middleware(
 )
 
 
+app.include_router(admin_router.router)
 app.include_router(auth_router.router)
 app.include_router(exercises_router.router)
 app.include_router(sessions_router.router)

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1,0 +1,148 @@
+from datetime import datetime, timezone
+
+import bcrypt
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy.orm import Session
+
+from auth import get_current_user
+from database import get_db
+from models.cardio import CardioEntry
+from models.measurement import BodyMeasurement
+from models.user import User
+from models.workout import Log, WorkoutSession
+
+router = APIRouter(prefix="/api/admin", tags=["admin"])
+
+
+def _require_admin(current_user: User = Depends(get_current_user)) -> User:
+    if not current_user.is_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Admin access required"
+        )
+    return current_user
+
+
+def _hash_password(plain: str) -> str:
+    return bcrypt.hashpw(plain.encode(), bcrypt.gensalt()).decode()
+
+
+class UserOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    username: str
+    email: str | None
+    display_name: str | None
+    is_active: bool
+    is_admin: bool
+    created_at: datetime
+
+
+class CreateUserRequest(BaseModel):
+    username: str
+    password: str = Field(min_length=8)
+    email: str | None = None
+    display_name: str | None = None
+    is_admin: bool = False
+
+
+class PatchUserRequest(BaseModel):
+    is_active: bool | None = None
+    is_admin: bool | None = None
+
+
+@router.get("/users", response_model=list[UserOut])
+def list_users(
+    db: Session = Depends(get_db),
+    _: User = Depends(_require_admin),
+):
+    return db.query(User).order_by(User.created_at).all()
+
+
+@router.post("/users", response_model=UserOut, status_code=status.HTTP_201_CREATED)
+def create_user(
+    body: CreateUserRequest,
+    db: Session = Depends(get_db),
+    _: User = Depends(_require_admin),
+):
+    if db.query(User).filter(User.username == body.username).first():
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail="Username already taken"
+        )
+    user = User(
+        username=body.username,
+        hashed_password=_hash_password(body.password),
+        email=body.email,
+        display_name=body.display_name,
+        is_active=True,
+        is_admin=body.is_admin,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@router.patch("/users/{user_id}", response_model=UserOut)
+def patch_user(
+    user_id: int,
+    body: PatchUserRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(_require_admin),
+):
+    user = db.get(User, user_id)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
+        )
+    if user.id == current_user.id and body.is_active is False:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot disable your own account",
+        )
+    for field, value in body.model_dump(exclude_unset=True).items():
+        setattr(user, field, value)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@router.delete("/users/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_user(
+    user_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(_require_admin),
+):
+    user = db.get(User, user_id)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
+        )
+    if user.id == current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot delete your own account",
+        )
+    session_ids = [
+        s.id
+        for s in db.query(WorkoutSession)
+        .filter(WorkoutSession.user_id == user_id)
+        .all()
+    ]
+    if session_ids:
+        db.query(Log).filter(Log.session_id.in_(session_ids)).delete(
+            synchronize_session=False
+        )
+    db.query(WorkoutSession).filter(WorkoutSession.user_id == user_id).delete(
+        synchronize_session=False
+    )
+    db.query(CardioEntry).filter(CardioEntry.user_id == user_id).delete(
+        synchronize_session=False
+    )
+    db.query(BodyMeasurement).filter(BodyMeasurement.user_id == user_id).delete(
+        synchronize_session=False
+    )
+    db.delete(user)
+    db.commit()

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -202,6 +202,7 @@ def test_enable_user_restores_login(client: TestClient):
 def test_admin_cannot_disable_self(client: TestClient):
     db = SessionLocal()
     testuser = db.query(User).filter(User.username == "testuser").first()
+    assert testuser is not None
     user_id = testuser.id
     db.close()
     resp = client.patch(
@@ -267,6 +268,7 @@ def test_delete_user_removes_their_data(client: TestClient):
 def test_admin_cannot_delete_self(client: TestClient):
     db = SessionLocal()
     testuser = db.query(User).filter(User.username == "testuser").first()
+    assert testuser is not None
     user_id = testuser.id
     db.close()
     resp = client.delete(f"/api/admin/users/{user_id}", headers=_admin_headers(client))

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -1,0 +1,273 @@
+from datetime import datetime, timezone
+
+import bcrypt
+from fastapi.testclient import TestClient
+
+from database import SessionLocal
+from models.user import User
+
+
+def _admin_headers(client: TestClient) -> dict:
+    token = client.post(
+        "/api/auth/login", json={"username": "testuser", "password": "testpass"}
+    ).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _make_user(
+    username: str, password: str = "pass1234", is_admin: bool = False
+) -> int:
+    db = SessionLocal()
+    hashed = bcrypt.hashpw(password.encode(), bcrypt.gensalt(rounds=4)).decode()
+    user = User(
+        username=username,
+        hashed_password=hashed,
+        is_active=True,
+        is_admin=is_admin,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    user_id = user.id
+    db.close()
+    return user_id
+
+
+def _nonadmin_headers(client: TestClient) -> dict:
+    db = SessionLocal()
+    exists = db.query(User).filter(User.username == "nonadmin_user").first()
+    db.close()
+    if not exists:
+        _make_user("nonadmin_user")
+    token = client.post(
+        "/api/auth/login", json={"username": "nonadmin_user", "password": "pass1234"}
+    ).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ── GET /api/admin/users ──────────────────────────────────────────────────────
+
+
+def test_list_users_requires_auth(client: TestClient):
+    assert client.get("/api/admin/users").status_code == 401
+
+
+def test_list_users_requires_admin(client: TestClient):
+    assert (
+        client.get("/api/admin/users", headers=_nonadmin_headers(client)).status_code
+        == 403
+    )
+
+
+def test_list_users_returns_all_users(client: TestClient):
+    resp = client.get("/api/admin/users", headers=_admin_headers(client))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    usernames = [u["username"] for u in data]
+    assert "testuser" in usernames
+
+
+def test_list_users_returns_correct_fields(client: TestClient):
+    resp = client.get("/api/admin/users", headers=_admin_headers(client))
+    user = next(u for u in resp.json() if u["username"] == "testuser")
+    for field in (
+        "id",
+        "username",
+        "email",
+        "display_name",
+        "is_active",
+        "is_admin",
+        "created_at",
+    ):
+        assert field in user
+
+
+# ── POST /api/admin/users ─────────────────────────────────────────────────────
+
+
+def test_create_user_requires_auth(client: TestClient):
+    assert (
+        client.post(
+            "/api/admin/users", json={"username": "x", "password": "pass1234"}
+        ).status_code
+        == 401
+    )
+
+
+def test_create_user_requires_admin(client: TestClient):
+    assert (
+        client.post(
+            "/api/admin/users",
+            json={"username": "newone", "password": "pass1234"},
+            headers=_nonadmin_headers(client),
+        ).status_code
+        == 403
+    )
+
+
+def test_create_user_success(client: TestClient):
+    resp = client.post(
+        "/api/admin/users",
+        json={"username": "invited_user", "password": "temppass1"},
+        headers=_admin_headers(client),
+    )
+    assert resp.status_code == 201
+    assert resp.json()["username"] == "invited_user"
+    assert (
+        client.post(
+            "/api/auth/login",
+            json={"username": "invited_user", "password": "temppass1"},
+        ).status_code
+        == 200
+    )
+
+
+def test_create_user_duplicate_username_returns_409(client: TestClient):
+    client.post(
+        "/api/admin/users",
+        json={"username": "dup_user", "password": "pass1234"},
+        headers=_admin_headers(client),
+    )
+    resp = client.post(
+        "/api/admin/users",
+        json={"username": "dup_user", "password": "pass1234"},
+        headers=_admin_headers(client),
+    )
+    assert resp.status_code == 409
+
+
+def test_create_user_rejects_short_password(client: TestClient):
+    resp = client.post(
+        "/api/admin/users",
+        json={"username": "shortpw_user", "password": "short"},
+        headers=_admin_headers(client),
+    )
+    assert resp.status_code == 422
+
+
+# ── PATCH /api/admin/users/{id} ───────────────────────────────────────────────
+
+
+def test_disable_user_requires_admin(client: TestClient):
+    user_id = _make_user("disable_target")
+    assert (
+        client.patch(
+            f"/api/admin/users/{user_id}",
+            json={"is_active": False},
+            headers=_nonadmin_headers(client),
+        ).status_code
+        == 403
+    )
+
+
+def test_disable_user_prevents_login(client: TestClient):
+    user_id = _make_user("to_be_disabled", "pass1234")
+    client.patch(
+        f"/api/admin/users/{user_id}",
+        json={"is_active": False},
+        headers=_admin_headers(client),
+    )
+    assert (
+        client.post(
+            "/api/auth/login",
+            json={"username": "to_be_disabled", "password": "pass1234"},
+        ).status_code
+        == 401
+    )
+
+
+def test_enable_user_restores_login(client: TestClient):
+    user_id = _make_user("to_be_reenabled", "pass1234")
+    client.patch(
+        f"/api/admin/users/{user_id}",
+        json={"is_active": False},
+        headers=_admin_headers(client),
+    )
+    client.patch(
+        f"/api/admin/users/{user_id}",
+        json={"is_active": True},
+        headers=_admin_headers(client),
+    )
+    assert (
+        client.post(
+            "/api/auth/login",
+            json={"username": "to_be_reenabled", "password": "pass1234"},
+        ).status_code
+        == 200
+    )
+
+
+def test_admin_cannot_disable_self(client: TestClient):
+    db = SessionLocal()
+    testuser = db.query(User).filter(User.username == "testuser").first()
+    user_id = testuser.id
+    db.close()
+    resp = client.patch(
+        f"/api/admin/users/{user_id}",
+        json={"is_active": False},
+        headers=_admin_headers(client),
+    )
+    assert resp.status_code == 400
+
+
+# ── DELETE /api/admin/users/{id} ─────────────────────────────────────────────
+
+
+def test_delete_user_requires_admin(client: TestClient):
+    user_id = _make_user("delete_target_auth")
+    assert (
+        client.delete(
+            f"/api/admin/users/{user_id}", headers=_nonadmin_headers(client)
+        ).status_code
+        == 403
+    )
+
+
+def test_delete_user_success(client: TestClient):
+    user_id = _make_user("to_be_deleted", "pass1234")
+    resp = client.delete(f"/api/admin/users/{user_id}", headers=_admin_headers(client))
+    assert resp.status_code == 204
+    usernames = [
+        u["username"]
+        for u in client.get("/api/admin/users", headers=_admin_headers(client)).json()
+    ]
+    assert "to_be_deleted" not in usernames
+
+
+def test_delete_user_removes_their_data(client: TestClient):
+    from datetime import datetime
+    from datetime import timezone as tz
+
+    from models.workout import WorkoutSession
+
+    user_id = _make_user("data_owner", "pass1234")
+    db = SessionLocal()
+    db.add(
+        WorkoutSession(
+            user_id=user_id,
+            session="Push A",
+            started_at=datetime.now(tz.utc),
+        )
+    )
+    db.commit()
+    db.close()
+
+    client.delete(f"/api/admin/users/{user_id}", headers=_admin_headers(client))
+
+    db = SessionLocal()
+    remaining = (
+        db.query(WorkoutSession).filter(WorkoutSession.user_id == user_id).count()
+    )
+    db.close()
+    assert remaining == 0
+
+
+def test_admin_cannot_delete_self(client: TestClient):
+    db = SessionLocal()
+    testuser = db.query(User).filter(User.username == "testuser").first()
+    user_id = testuser.id
+    db.close()
+    resp = client.delete(f"/api/admin/users/{user_id}", headers=_admin_headers(client))
+    assert resp.status_code == 400


### PR DESCRIPTION
Closes #107

## What changed

- `GET /api/admin/users` — returns all users with id, username, email, display_name, is_active, is_admin, created_at
- `POST /api/admin/users` — creates a new user (admin sets username + password); min 8-char password enforced; 409 on duplicate username
- `PATCH /api/admin/users/{id}` — enables or disables an account; blocks an admin from disabling their own account (400)
- `DELETE /api/admin/users/{id}` — deletes a user and cascades to their workout sessions, logs, cardio entries, and body measurements; blocks self-deletion (400)
- All endpoints return 401 without a token and 403 for non-admin users
- TESTING.md updated with test_admin.py entry

## Test plan

- [ ] 127 tests pass, 0 warnings
- [ ] Non-admin token → 403 on all admin endpoints
- [ ] Create user → new user can log in with the temp password
- [ ] Disable user → login returns 401; re-enable → login succeeds again
- [ ] Admin cannot disable or delete their own account
- [ ] Delete user → no longer in user list; their workout sessions are removed from the DB