### PR TITLE
feat: right to erasure endpoint — GDPR Article 17 (#135)

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -39,6 +39,7 @@ All tests live in `backend/tests/`. The suite uses a single in-memory SQLite dat
 | `test_auth.py` | Password hashing, login, registration validation (min length), JWT-protected endpoints, password change (wrong current → 400, short new → 422, success) |
 | `test_cardio.py` | Cardio entry logging, list, delete, activity validation, schema contract (no `session_id`) |
 | `test_exercises.py` | Exercise list (session + search filters), exercise by ID, sessions list |
+| `test_gdpr.py` | Right to erasure: 401 without token, 204 on success, user deleted (login fails), workout/cardio/measurement data cascade deleted |
 | `test_formulas.py` | Body composition formula calculations (BMI, fat mass, lean mass, BMR, segmental values) — pure unit tests, no HTTP |
 | `test_isolation.py` | Per-user data isolation: user B cannot read user A's sessions, cardio, or measurements |
 | `test_logs.py` | Set logging validation (`weight >= 0`, `reps > 0`), POST edge cases (bad IDs), GET last log, GET log list |

--- a/backend/main.py
+++ b/backend/main.py
@@ -11,6 +11,7 @@ from routers import admin as admin_router
 from routers import auth as auth_router
 from routers import cardio as cardio_router
 from routers import exercises as exercises_router
+from routers import gdpr as gdpr_router
 from routers import logs as logs_router
 from routers import measurements as measurements_router
 from routers import profile as profile_router
@@ -62,6 +63,7 @@ app.include_router(logs_router.router)
 app.include_router(progress_router.router)
 app.include_router(measurements_router.router)
 app.include_router(cardio_router.router)
+app.include_router(gdpr_router.router)
 app.include_router(profile_router.router)
 app.include_router(stats_router.router)
 

--- a/backend/routers/gdpr.py
+++ b/backend/routers/gdpr.py
@@ -1,0 +1,40 @@
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.orm import Session
+
+from auth import get_current_user
+from database import get_db
+from models.cardio import CardioEntry
+from models.measurement import BodyMeasurement
+from models.user import User
+from models.workout import Log, WorkoutSession
+
+router = APIRouter(prefix="/api/gdpr", tags=["gdpr"])
+
+
+@router.delete("/erase", status_code=status.HTTP_204_NO_CONTENT)
+def erase_my_data(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    user_id = current_user.id
+    session_ids = [
+        s.id
+        for s in db.query(WorkoutSession)
+        .filter(WorkoutSession.user_id == user_id)
+        .all()
+    ]
+    if session_ids:
+        db.query(Log).filter(Log.session_id.in_(session_ids)).delete(
+            synchronize_session=False
+        )
+    db.query(WorkoutSession).filter(WorkoutSession.user_id == user_id).delete(
+        synchronize_session=False
+    )
+    db.query(CardioEntry).filter(CardioEntry.user_id == user_id).delete(
+        synchronize_session=False
+    )
+    db.query(BodyMeasurement).filter(BodyMeasurement.user_id == user_id).delete(
+        synchronize_session=False
+    )
+    db.delete(current_user)
+    db.commit()

--- a/backend/tests/test_gdpr.py
+++ b/backend/tests/test_gdpr.py
@@ -1,0 +1,132 @@
+from datetime import datetime, timezone
+
+import bcrypt
+from fastapi.testclient import TestClient
+
+from database import SessionLocal
+from models.cardio import CardioEntry
+from models.measurement import BodyMeasurement
+from models.user import User
+from models.workout import Log, WorkoutSession
+
+
+def _make_user(username: str, password: str = "pass1234") -> int:
+    db = SessionLocal()
+    hashed = bcrypt.hashpw(password.encode(), bcrypt.gensalt(rounds=4)).decode()
+    user = User(
+        username=username,
+        hashed_password=hashed,
+        is_active=True,
+        is_admin=False,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    user_id = user.id
+    db.close()
+    return user_id
+
+
+def _login(client: TestClient, username: str, password: str = "pass1234") -> dict:
+    token = client.post(
+        "/api/auth/login", json={"username": username, "password": password}
+    ).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _seed_data(user_id: int) -> None:
+    db = SessionLocal()
+    session = WorkoutSession(
+        user_id=user_id,
+        session="Push A",
+        started_at=datetime.now(timezone.utc),
+    )
+    db.add(session)
+    db.commit()
+    db.refresh(session)
+    db.add(
+        Log(
+            session_id=session.id,
+            exercise_id=1,
+            weight=80.0,
+            reps=8,
+            logged_at=datetime.now(timezone.utc),
+        )
+    )
+    db.add(
+        CardioEntry(
+            user_id=user_id,
+            activity="run",
+            duration_s=1800,
+            logged_at=datetime.now(timezone.utc),
+        )
+    )
+    db.add(
+        BodyMeasurement(
+            user_id=user_id,
+            weight_kg=80.0,
+            recorded_at=datetime.now(timezone.utc),
+        )
+    )
+    db.commit()
+    db.close()
+
+
+# ── DELETE /api/gdpr/erase ────────────────────────────────────────────────────
+
+
+def test_erase_requires_auth(client: TestClient):
+    assert client.delete("/api/gdpr/erase").status_code == 401
+
+
+def test_erase_returns_204(client: TestClient):
+    _make_user("erase_user_204")
+    resp = client.delete("/api/gdpr/erase", headers=_login(client, "erase_user_204"))
+    assert resp.status_code == 204
+
+
+def test_erase_deletes_user_account(client: TestClient):
+    _make_user("erase_user_login")
+    client.delete("/api/gdpr/erase", headers=_login(client, "erase_user_login"))
+    assert (
+        client.post(
+            "/api/auth/login",
+            json={"username": "erase_user_login", "password": "pass1234"},
+        ).status_code
+        == 401
+    )
+
+
+def test_erase_deletes_workout_data(client: TestClient):
+    user_id = _make_user("erase_user_workout")
+    _seed_data(user_id)
+    client.delete("/api/gdpr/erase", headers=_login(client, "erase_user_workout"))
+    db = SessionLocal()
+    sessions = (
+        db.query(WorkoutSession).filter(WorkoutSession.user_id == user_id).count()
+    )
+    db.close()
+    assert sessions == 0
+
+
+def test_erase_deletes_cardio_data(client: TestClient):
+    user_id = _make_user("erase_user_cardio")
+    _seed_data(user_id)
+    client.delete("/api/gdpr/erase", headers=_login(client, "erase_user_cardio"))
+    db = SessionLocal()
+    entries = db.query(CardioEntry).filter(CardioEntry.user_id == user_id).count()
+    db.close()
+    assert entries == 0
+
+
+def test_erase_deletes_measurement_data(client: TestClient):
+    user_id = _make_user("erase_user_measurements")
+    _seed_data(user_id)
+    client.delete("/api/gdpr/erase", headers=_login(client, "erase_user_measurements"))
+    db = SessionLocal()
+    measurements = (
+        db.query(BodyMeasurement).filter(BodyMeasurement.user_id == user_id).count()
+    )
+    db.close()
+    assert measurements == 0


### PR DESCRIPTION
Closes #135

## What changed

- `DELETE /api/gdpr/erase` — authenticated users can delete their own account and all associated data in a single transaction
- Cascade order: logs → workout sessions → cardio entries → body measurements → user row
- Returns 204; subsequent login with the same credentials returns 401
- New `routers/gdpr.py` — home for all M15 GDPR endpoints
- TESTING.md updated with test_gdpr.py entry

## Test plan

- [ ] 133 tests pass, 0 warnings
- [ ] Without token → 401
- [ ] After erasure → login returns 401
- [ ] After erasure → workout sessions, cardio entries, and body measurements are gone from the DB