### PR TITLE
feat: data export endpoint — GDPR data portability (#136)

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -39,7 +39,7 @@ All tests live in `backend/tests/`. The suite uses a single in-memory SQLite dat
 | `test_auth.py` | Password hashing, login, registration validation (min length), JWT-protected endpoints, password change (wrong current → 400, short new → 422, success) |
 | `test_cardio.py` | Cardio entry logging, list, delete, activity validation, schema contract (no `session_id`) |
 | `test_exercises.py` | Exercise list (session + search filters), exercise by ID, sessions list |
-| `test_gdpr.py` | Right to erasure: 401 without token, 204 on success, user deleted (login fails), workout/cardio/measurement data cascade deleted |
+| `test_gdpr.py` | Right to erasure (401, 204, cascade delete); data export (401, structure, no password hash, Content-Disposition header, workout sessions included) |
 | `test_formulas.py` | Body composition formula calculations (BMI, fat mass, lean mass, BMR, segmental values) — pure unit tests, no HTTP |
 | `test_isolation.py` | Per-user data isolation: user B cannot read user A's sessions, cardio, or measurements |
 | `test_logs.py` | Set logging validation (`weight >= 0`, `reps > 0`), POST edge cases (bad IDs), GET last log, GET log list |

--- a/backend/routers/gdpr.py
+++ b/backend/routers/gdpr.py
@@ -1,4 +1,7 @@
+from datetime import datetime, timezone
+
 from fastapi import APIRouter, Depends, status
+from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
 from auth import get_current_user
@@ -38,3 +41,91 @@ def erase_my_data(
     )
     db.delete(current_user)
     db.commit()
+
+
+@router.get("/export")
+def export_my_data(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    user_id = current_user.id
+
+    sessions = db.query(WorkoutSession).filter(WorkoutSession.user_id == user_id).all()
+    session_ids = [s.id for s in sessions]
+
+    logs = (
+        db.query(Log).filter(Log.session_id.in_(session_ids)).all()
+        if session_ids
+        else []
+    )
+    cardio = db.query(CardioEntry).filter(CardioEntry.user_id == user_id).all()
+    measurements = (
+        db.query(BodyMeasurement).filter(BodyMeasurement.user_id == user_id).all()
+    )
+
+    def _dt(v: object) -> object:
+        return v.isoformat() if isinstance(v, datetime) else v
+
+    payload = {
+        "exported_at": datetime.now(timezone.utc).isoformat(),
+        "user": {
+            "username": current_user.username,
+            "email": current_user.email,
+            "display_name": current_user.display_name,
+            "birth_year": current_user.birth_year,
+            "sex": current_user.sex,
+            "height_cm": current_user.height_cm,
+            "is_admin": current_user.is_admin,
+            "created_at": _dt(current_user.created_at),
+        },
+        "workout_sessions": [
+            {
+                "id": s.id,
+                "session": s.session,
+                "started_at": _dt(s.started_at),
+                "ended_at": _dt(s.ended_at),
+            }
+            for s in sessions
+        ],
+        "logs": [
+            {
+                "id": log.id,
+                "session_id": log.session_id,
+                "exercise_id": log.exercise_id,
+                "weight": log.weight,
+                "reps": log.reps,
+                "logged_at": _dt(log.logged_at),
+            }
+            for log in logs
+        ],
+        "cardio": [
+            {
+                "id": c.id,
+                "activity": c.activity,
+                "distance_m": c.distance_m,
+                "duration_s": c.duration_s,
+                "notes": c.notes,
+                "logged_at": _dt(c.logged_at),
+            }
+            for c in cardio
+        ],
+        "body_measurements": [
+            {
+                "id": m.id,
+                "recorded_at": _dt(m.recorded_at),
+                "weight_kg": m.weight_kg,
+                "body_fat_pct": m.body_fat_pct,
+                "height_cm": m.height_cm,
+                "bmi": m.bmi,
+                "fat_mass_kg": m.fat_mass_kg,
+                "lean_mass_kg": m.lean_mass_kg,
+                "bmr_kcal": m.bmr_kcal,
+            }
+            for m in measurements
+        ],
+    }
+
+    return JSONResponse(
+        content=payload,
+        headers={"Content-Disposition": 'attachment; filename="fitman-export.json"'},
+    )

--- a/backend/tests/test_gdpr.py
+++ b/backend/tests/test_gdpr.py
@@ -130,3 +130,68 @@ def test_erase_deletes_measurement_data(client: TestClient):
     )
     db.close()
     assert measurements == 0
+
+
+# ── GET /api/gdpr/export ──────────────────────────────────────────────────────
+
+
+def test_export_requires_auth(client: TestClient):
+    assert client.get("/api/gdpr/export").status_code == 401
+
+
+def test_export_returns_200(client: TestClient):
+    assert (
+        client.get(
+            "/api/gdpr/export", headers=_login(client, "testuser", "testpass")
+        ).status_code
+        == 200
+    )
+
+
+def test_export_has_correct_structure(client: TestClient):
+    data = client.get(
+        "/api/gdpr/export", headers=_login(client, "testuser", "testpass")
+    ).json()
+    for key in (
+        "exported_at",
+        "user",
+        "workout_sessions",
+        "logs",
+        "cardio",
+        "body_measurements",
+    ):
+        assert key in data
+
+
+def test_export_excludes_password_hash(client: TestClient):
+    data = client.get(
+        "/api/gdpr/export", headers=_login(client, "testuser", "testpass")
+    ).json()
+    assert "hashed_password" not in data["user"]
+
+
+def test_export_includes_username(client: TestClient):
+    data = client.get(
+        "/api/gdpr/export", headers=_login(client, "testuser", "testpass")
+    ).json()
+    assert data["user"]["username"] == "testuser"
+
+
+def test_export_sets_content_disposition(client: TestClient):
+    resp = client.get(
+        "/api/gdpr/export", headers=_login(client, "testuser", "testpass")
+    )
+    assert "attachment" in resp.headers.get("content-disposition", "")
+    assert "fitman-export.json" in resp.headers.get("content-disposition", "")
+
+
+def test_export_includes_workout_sessions(client: TestClient):
+    _make_user("export_data_user")
+    headers = _login(client, "export_data_user")
+    session = client.post(
+        "/api/sessions", json={"session": "Push A"}, headers=headers
+    ).json()
+    client.patch(f"/api/sessions/{session['id']}/end", headers=headers)
+    data = client.get("/api/gdpr/export", headers=headers).json()
+    assert isinstance(data["workout_sessions"], list)
+    assert any(s["id"] == session["id"] for s in data["workout_sessions"])


### PR DESCRIPTION
Closes #136

## What changed

- `GET /api/gdpr/export` — returns a JSON file with all user data: profile fields (no password hash), workout sessions, logs, cardio entries, and body measurements
- Response sets `Content-Disposition: attachment; filename="fitman-export.json"` so browsers trigger a file download
- All datetime fields serialised to ISO 8601 strings

## Test plan

- [ ] 140 tests pass, 0 warnings
- [ ] Without token → 401
- [ ] Response contains exported_at, user, workout_sessions, logs, cardio, body_measurements
- [ ] hashed_password absent from user section
- [ ] Content-Disposition header present with correct filename
- [ ] Workout sessions created via API appear in the export