### PR TITLE
feat: privacy notice and consent at first-run registration (#138)

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -36,7 +36,7 @@ All tests live in `backend/tests/`. The suite uses a single in-memory SQLite dat
 | File | What it covers |
 |---|---|
 | `test_admin.py` | Admin user management: list users, create, disable/enable, delete (with data cascade); 403 for non-admins, self-disable/delete blocked |
-| `test_auth.py` | Password hashing, login, registration validation (min length), JWT-protected endpoints, password change (wrong current → 400, short new → 422, success) |
+| `test_auth.py` | Password hashing, login, registration validation (min length, consent required), JWT-protected endpoints, password change (wrong current → 400, short new → 422, success) |
 | `test_cardio.py` | Cardio entry logging, list, delete, activity validation, schema contract (no `session_id`) |
 | `test_exercises.py` | Exercise list (session + search filters), exercise by ID, sessions list |
 | `test_gdpr.py` | Right to erasure (401, 204, cascade delete); data export (401, structure, no password hash, Content-Disposition header, workout sessions included) |

--- a/backend/alembic/versions/d5e8f2a1b4c7_add_consent_given_at_to_users.py
+++ b/backend/alembic/versions/d5e8f2a1b4c7_add_consent_given_at_to_users.py
@@ -1,0 +1,26 @@
+"""add consent_given_at to users
+
+Revision ID: d5e8f2a1b4c7
+Revises: c4a7b2e5f1d9
+Create Date: 2026-07-05
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d5e8f2a1b4c7"
+down_revision: Union[str, Sequence[str], None] = "c4a7b2e5f1d9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.add_column(sa.Column("consent_given_at", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.drop_column("consent_given_at")

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -20,3 +20,4 @@ class User(Base):
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     is_admin: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     created_at: Mapped[datetime] = mapped_column(TZDateTime, nullable=False)
+    consent_given_at: Mapped[datetime | None] = mapped_column(TZDateTime)

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from typing import Literal
 
 import bcrypt
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -29,6 +30,7 @@ class RegisterRequest(BaseModel):
     username: str
     password: str = Field(min_length=8)
     display_name: str | None = None
+    consent_given: Literal[True]
 
 
 class TokenResponse(BaseModel):
@@ -68,6 +70,7 @@ def register(body: RegisterRequest, db: Session = Depends(get_db)):
         is_active=True,
         is_admin=True,  # first user is always admin
         created_at=datetime.now(timezone.utc),
+        consent_given_at=datetime.now(timezone.utc),
     )
     db.add(user)
     db.commit()

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -31,7 +31,8 @@ def test_setup_not_required_when_user_exists(client: TestClient):
 
 def test_register_fails_when_user_exists(client: TestClient):
     resp = client.post(
-        "/api/auth/register", json={"username": "newuser", "password": "pass1234"}
+        "/api/auth/register",
+        json={"username": "newuser", "password": "pass1234", "consent_given": True},
     )
     assert resp.status_code == 409
 
@@ -109,7 +110,8 @@ def test_register_accepts_minimum_length_password(client: TestClient):
     """Boundary: 8-char password must pass Pydantic validation.
     Setup already complete so DB returns 409 — but not 422, proving validation passed."""
     resp = client.post(
-        "/api/auth/register", json={"username": "newuser", "password": "12345678"}
+        "/api/auth/register",
+        json={"username": "newuser", "password": "12345678", "consent_given": True},
     )
     assert resp.status_code == 409
 
@@ -197,3 +199,50 @@ def test_change_password_old_password_rejected_after_change(client: TestClient):
         ).status_code
         == 401
     )
+
+
+# ── Consent at registration (Issue #138) ─────────────────────────────────────
+
+
+def test_register_without_consent_returns_422(client: TestClient):
+    """consent_given field missing entirely — Pydantic must reject it."""
+    resp = client.post(
+        "/api/auth/register", json={"username": "consent_user", "password": "pass1234"}
+    )
+    assert resp.status_code == 422
+
+
+def test_register_with_consent_false_returns_422(client: TestClient):
+    """consent_given=False must be rejected — only True is accepted."""
+    resp = client.post(
+        "/api/auth/register",
+        json={
+            "username": "consent_user",
+            "password": "pass1234",
+            "consent_given": False,
+        },
+    )
+    assert resp.status_code == 422
+
+
+def test_register_with_consent_true_passes_validation(client: TestClient):
+    """consent_given=True passes validation. DB returns 409 (user already exists)
+    which proves the payload was valid and consent was accepted."""
+    resp = client.post(
+        "/api/auth/register",
+        json={
+            "username": "consent_user",
+            "password": "pass1234",
+            "consent_given": True,
+        },
+    )
+    assert resp.status_code == 409
+
+
+def test_consent_given_at_column_exists(client: TestClient):
+    """The consent_given_at column must exist on the User model after migration."""
+    db = SessionLocal()
+    user = db.query(User).filter(User.username == "testuser").first()
+    assert user is not None
+    assert hasattr(user, "consent_given_at")
+    db.close()


### PR DESCRIPTION
Closes #138

## What changed

- `RegisterRequest` now requires `consent_given: Literal[True]` — missing or False returns 422 before touching the DB
- `User.consent_given_at` — new nullable datetime column; populated with the server timestamp on registration
- Migration `d5e8f2a1b4c7` — adds `consent_given_at` column to users table (nullable, existing rows get NULL)
- Two existing registration tests updated to include `consent_given: True` (they relied on reaching the DB to get 409; now they need valid consent to get there)
- TESTING.md updated to reflect consent validation in test_auth.py

## Test plan

- [ ] 144 tests pass, 0 warnings
- [ ] Register without `consent_given` → 422
- [ ] Register with `consent_given: false` → 422
- [ ] Register with `consent_given: true` → 409 (DB blocks duplicate, proving validation passed)
- [ ] `consent_given_at` attribute exists on User model