### PR TITLE
M15 · GDPR & data security — close milestone

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -115,6 +115,7 @@ users
   is_active       BOOLEAN NOT NULL DEFAULT 1
   is_admin        BOOLEAN NOT NULL DEFAULT 0
   created_at      TEXT NOT NULL
+  consent_given_at TEXT                   -- ISO timestamp; NULL for users created before #138
 ```
 
 ### Strength training
@@ -242,6 +243,10 @@ DELETE /api/cardio/{id}                  Delete a cardio entry
 POST   /api/measurements                  Log a measurement { weight_kg, body_fat_pct, ... }
 GET    /api/measurements                  All measurements (newest first)
 DELETE /api/measurements/{id}            Delete a measurement
+
+# GDPR
+DELETE /api/gdpr/erase                   Delete own account and all associated data (GDPR Article 17)
+GET    /api/gdpr/export                  Download all own data as JSON (GDPR Article 20)
 
 # System
 GET    /health                            Health check

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -298,6 +298,25 @@ The user model stores `birth_year` (integer) rather than a full date-of-birth. F
 
 Symmetric encryption of the full DOB was considered but deferred — it adds key-management complexity that is disproportionate to the threat model of a self-hosted, Tailscale-only app. This can be revisited in the M15 GDPR & data-security milestone if the threat model changes.
 
+### Encryption at rest — filesystem-level, not application-level
+
+GDPR Article 32 requires "appropriate technical and organisational measures" to protect personal data. For Fitman's current scope (self-hosted, single-user or small household, accessed exclusively over Tailscale), the appropriate measure is **filesystem-level encryption on the host** rather than application-level column encryption.
+
+**Options evaluated:**
+
+| Option | Assessment |
+|---|---|
+| Filesystem / volume encryption | Recommended. Encrypts the entire SQLite file transparently. Zero app code changes. Protects against disk theft or backup exfiltration. |
+| SQLCipher (encrypted SQLite) | Requires rebuilding pysqlite against libsqlcipher. Fragile in Docker, significant build complexity for marginal gain over filesystem encryption. |
+| Column-level encryption (`cryptography` lib) | Most granular, but: requires managing an encryption key in `.env`, breaks `WHERE` queries on encrypted columns, complicates backups and exports. Disproportionate for this scope. |
+| PostgreSQL TDE / pgcrypto | Relevant if migrating to PostgreSQL (M19). Revisit then. |
+
+**Key management (filesystem approach):** Use Linux LUKS or macOS FileVault on the host machine, or encrypt the Docker volume via the host's block device. The `SECRET_KEY` in `.env` remains the only application-level secret and should not be committed to version control.
+
+**Backup note:** Encrypted backups are only as strong as the decryption key. Store backups on an encrypted medium and never in the same location as the key.
+
+**Revisit trigger:** If Fitman is ever deployed as a shared multi-user service (beyond household use), column-level encryption for health measurements should be implemented to comply with GDPR Article 32 in a multi-tenant context.
+
 ## Hosting & access
 
 - The server runs Docker Compose continuously (`docker compose -f docker-compose.prod.yml up -d`)

--- a/README.md
+++ b/README.md
@@ -171,6 +171,15 @@ See [SCALE.md](SCALE.md) for the smart scale BLE protocol, packet decoding, and 
 
 > ⚠️ **Medical disclaimer:** Body composition metrics beyond raw weight are estimates from BIA formulas for personal informational use only. The developers are not medical professionals. Do not use these values for medical diagnosis or treatment.
 
+## Privacy notice
+
+If you share this app with others on your Tailscale network, users should know:
+
+- **What is stored:** workout sessions, sets, cardio entries, body measurements (weight, body fat %, BIA impedance readings), and profile fields (display name, birth year, sex, height)
+- **Where it is stored:** exclusively on your self-hosted server — no data is sent to any third party
+- **User rights:** each user can export all their data (`GET /api/gdpr/export`) or permanently delete their account and all associated data (`DELETE /api/gdpr/erase`) at any time
+- **Encryption:** data is stored in a SQLite database file; protect it with filesystem-level encryption on the host (see [ARCHITECTURE.md](ARCHITECTURE.md) for the full decision)
+
 ## Branch strategy
 
 | Branch | Purpose |

--- a/TESTING.md
+++ b/TESTING.md
@@ -36,7 +36,7 @@ All tests live in `backend/tests/`. The suite uses a single in-memory SQLite dat
 | File | What it covers |
 |---|---|
 | `test_admin.py` | Admin user management: list users, create, disable/enable, delete (with data cascade); 403 for non-admins, self-disable/delete blocked |
-| `test_auth.py` | Password hashing, login, registration validation (min length), JWT-protected endpoints, password change (wrong current → 400, short new → 422, success) |
+| `test_auth.py` | Password hashing, login, registration validation (min length, consent required), JWT-protected endpoints, password change (wrong current → 400, short new → 422, success) |
 | `test_cardio.py` | Cardio entry logging, list, delete, activity validation, schema contract (no `session_id`) |
 | `test_exercises.py` | Exercise list (session + search filters), exercise by ID, sessions list |
 | `test_gdpr.py` | Right to erasure (401, 204, cascade delete); data export (401, structure, no password hash, Content-Disposition header, workout sessions included) |

--- a/TESTING.md
+++ b/TESTING.md
@@ -39,7 +39,7 @@ All tests live in `backend/tests/`. The suite uses a single in-memory SQLite dat
 | `test_auth.py` | Password hashing, login, registration validation (min length), JWT-protected endpoints, password change (wrong current → 400, short new → 422, success) |
 | `test_cardio.py` | Cardio entry logging, list, delete, activity validation, schema contract (no `session_id`) |
 | `test_exercises.py` | Exercise list (session + search filters), exercise by ID, sessions list |
-| `test_gdpr.py` | Right to erasure: 401 without token, 204 on success, user deleted (login fails), workout/cardio/measurement data cascade deleted |
+| `test_gdpr.py` | Right to erasure (401, 204, cascade delete); data export (401, structure, no password hash, Content-Disposition header, workout sessions included) |
 | `test_formulas.py` | Body composition formula calculations (BMI, fat mass, lean mass, BMR, segmental values) — pure unit tests, no HTTP |
 | `test_isolation.py` | Per-user data isolation: user B cannot read user A's sessions, cardio, or measurements |
 | `test_logs.py` | Set logging validation (`weight >= 0`, `reps > 0`), POST edge cases (bad IDs), GET last log, GET log list |

--- a/TESTING.md
+++ b/TESTING.md
@@ -39,6 +39,7 @@ All tests live in `backend/tests/`. The suite uses a single in-memory SQLite dat
 | `test_auth.py` | Password hashing, login, registration validation (min length), JWT-protected endpoints, password change (wrong current → 400, short new → 422, success) |
 | `test_cardio.py` | Cardio entry logging, list, delete, activity validation, schema contract (no `session_id`) |
 | `test_exercises.py` | Exercise list (session + search filters), exercise by ID, sessions list |
+| `test_gdpr.py` | Right to erasure: 401 without token, 204 on success, user deleted (login fails), workout/cardio/measurement data cascade deleted |
 | `test_formulas.py` | Body composition formula calculations (BMI, fat mass, lean mass, BMR, segmental values) — pure unit tests, no HTTP |
 | `test_isolation.py` | Per-user data isolation: user B cannot read user A's sessions, cardio, or measurements |
 | `test_logs.py` | Set logging validation (`weight >= 0`, `reps > 0`), POST edge cases (bad IDs), GET last log, GET log list |

--- a/backend/alembic/versions/d5e8f2a1b4c7_add_consent_given_at_to_users.py
+++ b/backend/alembic/versions/d5e8f2a1b4c7_add_consent_given_at_to_users.py
@@ -1,0 +1,26 @@
+"""add consent_given_at to users
+
+Revision ID: d5e8f2a1b4c7
+Revises: c4a7b2e5f1d9
+Create Date: 2026-07-05
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d5e8f2a1b4c7"
+down_revision: Union[str, Sequence[str], None] = "c4a7b2e5f1d9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.add_column(sa.Column("consent_given_at", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.drop_column("consent_given_at")

--- a/backend/main.py
+++ b/backend/main.py
@@ -11,6 +11,7 @@ from routers import admin as admin_router
 from routers import auth as auth_router
 from routers import cardio as cardio_router
 from routers import exercises as exercises_router
+from routers import gdpr as gdpr_router
 from routers import logs as logs_router
 from routers import measurements as measurements_router
 from routers import profile as profile_router
@@ -62,6 +63,7 @@ app.include_router(logs_router.router)
 app.include_router(progress_router.router)
 app.include_router(measurements_router.router)
 app.include_router(cardio_router.router)
+app.include_router(gdpr_router.router)
 app.include_router(profile_router.router)
 app.include_router(stats_router.router)
 

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -20,3 +20,4 @@ class User(Base):
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     is_admin: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     created_at: Mapped[datetime] = mapped_column(TZDateTime, nullable=False)
+    consent_given_at: Mapped[datetime | None] = mapped_column(TZDateTime)

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from typing import Literal
 
 import bcrypt
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -29,6 +30,7 @@ class RegisterRequest(BaseModel):
     username: str
     password: str = Field(min_length=8)
     display_name: str | None = None
+    consent_given: Literal[True]
 
 
 class TokenResponse(BaseModel):
@@ -68,6 +70,7 @@ def register(body: RegisterRequest, db: Session = Depends(get_db)):
         is_active=True,
         is_admin=True,  # first user is always admin
         created_at=datetime.now(timezone.utc),
+        consent_given_at=datetime.now(timezone.utc),
     )
     db.add(user)
     db.commit()

--- a/backend/routers/gdpr.py
+++ b/backend/routers/gdpr.py
@@ -1,0 +1,40 @@
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.orm import Session
+
+from auth import get_current_user
+from database import get_db
+from models.cardio import CardioEntry
+from models.measurement import BodyMeasurement
+from models.user import User
+from models.workout import Log, WorkoutSession
+
+router = APIRouter(prefix="/api/gdpr", tags=["gdpr"])
+
+
+@router.delete("/erase", status_code=status.HTTP_204_NO_CONTENT)
+def erase_my_data(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    user_id = current_user.id
+    session_ids = [
+        s.id
+        for s in db.query(WorkoutSession)
+        .filter(WorkoutSession.user_id == user_id)
+        .all()
+    ]
+    if session_ids:
+        db.query(Log).filter(Log.session_id.in_(session_ids)).delete(
+            synchronize_session=False
+        )
+    db.query(WorkoutSession).filter(WorkoutSession.user_id == user_id).delete(
+        synchronize_session=False
+    )
+    db.query(CardioEntry).filter(CardioEntry.user_id == user_id).delete(
+        synchronize_session=False
+    )
+    db.query(BodyMeasurement).filter(BodyMeasurement.user_id == user_id).delete(
+        synchronize_session=False
+    )
+    db.delete(current_user)
+    db.commit()

--- a/backend/routers/gdpr.py
+++ b/backend/routers/gdpr.py
@@ -1,4 +1,7 @@
+from datetime import datetime, timezone
+
 from fastapi import APIRouter, Depends, status
+from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
 from auth import get_current_user
@@ -38,3 +41,91 @@ def erase_my_data(
     )
     db.delete(current_user)
     db.commit()
+
+
+@router.get("/export")
+def export_my_data(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    user_id = current_user.id
+
+    sessions = db.query(WorkoutSession).filter(WorkoutSession.user_id == user_id).all()
+    session_ids = [s.id for s in sessions]
+
+    logs = (
+        db.query(Log).filter(Log.session_id.in_(session_ids)).all()
+        if session_ids
+        else []
+    )
+    cardio = db.query(CardioEntry).filter(CardioEntry.user_id == user_id).all()
+    measurements = (
+        db.query(BodyMeasurement).filter(BodyMeasurement.user_id == user_id).all()
+    )
+
+    def _dt(v: object) -> object:
+        return v.isoformat() if isinstance(v, datetime) else v
+
+    payload = {
+        "exported_at": datetime.now(timezone.utc).isoformat(),
+        "user": {
+            "username": current_user.username,
+            "email": current_user.email,
+            "display_name": current_user.display_name,
+            "birth_year": current_user.birth_year,
+            "sex": current_user.sex,
+            "height_cm": current_user.height_cm,
+            "is_admin": current_user.is_admin,
+            "created_at": _dt(current_user.created_at),
+        },
+        "workout_sessions": [
+            {
+                "id": s.id,
+                "session": s.session,
+                "started_at": _dt(s.started_at),
+                "ended_at": _dt(s.ended_at),
+            }
+            for s in sessions
+        ],
+        "logs": [
+            {
+                "id": log.id,
+                "session_id": log.session_id,
+                "exercise_id": log.exercise_id,
+                "weight": log.weight,
+                "reps": log.reps,
+                "logged_at": _dt(log.logged_at),
+            }
+            for log in logs
+        ],
+        "cardio": [
+            {
+                "id": c.id,
+                "activity": c.activity,
+                "distance_m": c.distance_m,
+                "duration_s": c.duration_s,
+                "notes": c.notes,
+                "logged_at": _dt(c.logged_at),
+            }
+            for c in cardio
+        ],
+        "body_measurements": [
+            {
+                "id": m.id,
+                "recorded_at": _dt(m.recorded_at),
+                "weight_kg": m.weight_kg,
+                "body_fat_pct": m.body_fat_pct,
+                "height_cm": m.height_cm,
+                "bmi": m.bmi,
+                "fat_mass_kg": m.fat_mass_kg,
+                "lean_mass_kg": m.lean_mass_kg,
+                "bmr_kcal": m.bmr_kcal,
+            }
+            for m in measurements
+        ],
+    }
+
+    return JSONResponse(
+        content=payload,
+        headers={"Content-Disposition": 'attachment; filename="fitman-export.json"'},
+    )

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -31,7 +31,8 @@ def test_setup_not_required_when_user_exists(client: TestClient):
 
 def test_register_fails_when_user_exists(client: TestClient):
     resp = client.post(
-        "/api/auth/register", json={"username": "newuser", "password": "pass1234"}
+        "/api/auth/register",
+        json={"username": "newuser", "password": "pass1234", "consent_given": True},
     )
     assert resp.status_code == 409
 
@@ -109,7 +110,8 @@ def test_register_accepts_minimum_length_password(client: TestClient):
     """Boundary: 8-char password must pass Pydantic validation.
     Setup already complete so DB returns 409 — but not 422, proving validation passed."""
     resp = client.post(
-        "/api/auth/register", json={"username": "newuser", "password": "12345678"}
+        "/api/auth/register",
+        json={"username": "newuser", "password": "12345678", "consent_given": True},
     )
     assert resp.status_code == 409
 
@@ -197,3 +199,50 @@ def test_change_password_old_password_rejected_after_change(client: TestClient):
         ).status_code
         == 401
     )
+
+
+# ── Consent at registration (Issue #138) ─────────────────────────────────────
+
+
+def test_register_without_consent_returns_422(client: TestClient):
+    """consent_given field missing entirely — Pydantic must reject it."""
+    resp = client.post(
+        "/api/auth/register", json={"username": "consent_user", "password": "pass1234"}
+    )
+    assert resp.status_code == 422
+
+
+def test_register_with_consent_false_returns_422(client: TestClient):
+    """consent_given=False must be rejected — only True is accepted."""
+    resp = client.post(
+        "/api/auth/register",
+        json={
+            "username": "consent_user",
+            "password": "pass1234",
+            "consent_given": False,
+        },
+    )
+    assert resp.status_code == 422
+
+
+def test_register_with_consent_true_passes_validation(client: TestClient):
+    """consent_given=True passes validation. DB returns 409 (user already exists)
+    which proves the payload was valid and consent was accepted."""
+    resp = client.post(
+        "/api/auth/register",
+        json={
+            "username": "consent_user",
+            "password": "pass1234",
+            "consent_given": True,
+        },
+    )
+    assert resp.status_code == 409
+
+
+def test_consent_given_at_column_exists(client: TestClient):
+    """The consent_given_at column must exist on the User model after migration."""
+    db = SessionLocal()
+    user = db.query(User).filter(User.username == "testuser").first()
+    assert user is not None
+    assert hasattr(user, "consent_given_at")
+    db.close()

--- a/backend/tests/test_gdpr.py
+++ b/backend/tests/test_gdpr.py
@@ -1,0 +1,132 @@
+from datetime import datetime, timezone
+
+import bcrypt
+from fastapi.testclient import TestClient
+
+from database import SessionLocal
+from models.cardio import CardioEntry
+from models.measurement import BodyMeasurement
+from models.user import User
+from models.workout import Log, WorkoutSession
+
+
+def _make_user(username: str, password: str = "pass1234") -> int:
+    db = SessionLocal()
+    hashed = bcrypt.hashpw(password.encode(), bcrypt.gensalt(rounds=4)).decode()
+    user = User(
+        username=username,
+        hashed_password=hashed,
+        is_active=True,
+        is_admin=False,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    user_id = user.id
+    db.close()
+    return user_id
+
+
+def _login(client: TestClient, username: str, password: str = "pass1234") -> dict:
+    token = client.post(
+        "/api/auth/login", json={"username": username, "password": password}
+    ).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _seed_data(user_id: int) -> None:
+    db = SessionLocal()
+    session = WorkoutSession(
+        user_id=user_id,
+        session="Push A",
+        started_at=datetime.now(timezone.utc),
+    )
+    db.add(session)
+    db.commit()
+    db.refresh(session)
+    db.add(
+        Log(
+            session_id=session.id,
+            exercise_id=1,
+            weight=80.0,
+            reps=8,
+            logged_at=datetime.now(timezone.utc),
+        )
+    )
+    db.add(
+        CardioEntry(
+            user_id=user_id,
+            activity="run",
+            duration_s=1800,
+            logged_at=datetime.now(timezone.utc),
+        )
+    )
+    db.add(
+        BodyMeasurement(
+            user_id=user_id,
+            weight_kg=80.0,
+            recorded_at=datetime.now(timezone.utc),
+        )
+    )
+    db.commit()
+    db.close()
+
+
+# ── DELETE /api/gdpr/erase ────────────────────────────────────────────────────
+
+
+def test_erase_requires_auth(client: TestClient):
+    assert client.delete("/api/gdpr/erase").status_code == 401
+
+
+def test_erase_returns_204(client: TestClient):
+    _make_user("erase_user_204")
+    resp = client.delete("/api/gdpr/erase", headers=_login(client, "erase_user_204"))
+    assert resp.status_code == 204
+
+
+def test_erase_deletes_user_account(client: TestClient):
+    _make_user("erase_user_login")
+    client.delete("/api/gdpr/erase", headers=_login(client, "erase_user_login"))
+    assert (
+        client.post(
+            "/api/auth/login",
+            json={"username": "erase_user_login", "password": "pass1234"},
+        ).status_code
+        == 401
+    )
+
+
+def test_erase_deletes_workout_data(client: TestClient):
+    user_id = _make_user("erase_user_workout")
+    _seed_data(user_id)
+    client.delete("/api/gdpr/erase", headers=_login(client, "erase_user_workout"))
+    db = SessionLocal()
+    sessions = (
+        db.query(WorkoutSession).filter(WorkoutSession.user_id == user_id).count()
+    )
+    db.close()
+    assert sessions == 0
+
+
+def test_erase_deletes_cardio_data(client: TestClient):
+    user_id = _make_user("erase_user_cardio")
+    _seed_data(user_id)
+    client.delete("/api/gdpr/erase", headers=_login(client, "erase_user_cardio"))
+    db = SessionLocal()
+    entries = db.query(CardioEntry).filter(CardioEntry.user_id == user_id).count()
+    db.close()
+    assert entries == 0
+
+
+def test_erase_deletes_measurement_data(client: TestClient):
+    user_id = _make_user("erase_user_measurements")
+    _seed_data(user_id)
+    client.delete("/api/gdpr/erase", headers=_login(client, "erase_user_measurements"))
+    db = SessionLocal()
+    measurements = (
+        db.query(BodyMeasurement).filter(BodyMeasurement.user_id == user_id).count()
+    )
+    db.close()
+    assert measurements == 0

--- a/backend/tests/test_gdpr.py
+++ b/backend/tests/test_gdpr.py
@@ -130,3 +130,68 @@ def test_erase_deletes_measurement_data(client: TestClient):
     )
     db.close()
     assert measurements == 0
+
+
+# ── GET /api/gdpr/export ──────────────────────────────────────────────────────
+
+
+def test_export_requires_auth(client: TestClient):
+    assert client.get("/api/gdpr/export").status_code == 401
+
+
+def test_export_returns_200(client: TestClient):
+    assert (
+        client.get(
+            "/api/gdpr/export", headers=_login(client, "testuser", "testpass")
+        ).status_code
+        == 200
+    )
+
+
+def test_export_has_correct_structure(client: TestClient):
+    data = client.get(
+        "/api/gdpr/export", headers=_login(client, "testuser", "testpass")
+    ).json()
+    for key in (
+        "exported_at",
+        "user",
+        "workout_sessions",
+        "logs",
+        "cardio",
+        "body_measurements",
+    ):
+        assert key in data
+
+
+def test_export_excludes_password_hash(client: TestClient):
+    data = client.get(
+        "/api/gdpr/export", headers=_login(client, "testuser", "testpass")
+    ).json()
+    assert "hashed_password" not in data["user"]
+
+
+def test_export_includes_username(client: TestClient):
+    data = client.get(
+        "/api/gdpr/export", headers=_login(client, "testuser", "testpass")
+    ).json()
+    assert data["user"]["username"] == "testuser"
+
+
+def test_export_sets_content_disposition(client: TestClient):
+    resp = client.get(
+        "/api/gdpr/export", headers=_login(client, "testuser", "testpass")
+    )
+    assert "attachment" in resp.headers.get("content-disposition", "")
+    assert "fitman-export.json" in resp.headers.get("content-disposition", "")
+
+
+def test_export_includes_workout_sessions(client: TestClient):
+    _make_user("export_data_user")
+    headers = _login(client, "export_data_user")
+    session = client.post(
+        "/api/sessions", json={"session": "Push A"}, headers=headers
+    ).json()
+    client.patch(f"/api/sessions/{session['id']}/end", headers=headers)
+    data = client.get("/api/gdpr/export", headers=headers).json()
+    assert isinstance(data["workout_sessions"], list)
+    assert any(s["id"] == session["id"] for s in data["workout_sessions"])


### PR DESCRIPTION
Closes #135, #136, #137, #138

## Summary

- **#135 — Right to erasure**: `DELETE /api/gdpr/erase` — authenticated users can permanently delete their own account and all associated data (workout sessions, logs, cardio entries, body measurements) in a single transaction. Returns 204.

- **#136 — Data export**: `GET /api/gdpr/export` — returns a JSON file with all user data (profile, sessions, logs, cardio, measurements). Password hash excluded. Response sets `Content-Disposition: attachment; filename="fitman-export.json"`.

- **#137 — Encryption at rest**: Decision documented in ARCHITECTURE.md. Filesystem-level encryption on the host is the appropriate measure for a self-hosted, Tailscale-only app. Column-level encryption evaluated and deferred — disproportionate for this scope, revisit trigger documented.

- **#138 — Consent at registration**: `RegisterRequest` now requires `consent_given: Literal[True]` — missing or False returns 422. `User.consent_given_at` column added via migration `d5e8f2a1b4c7`; populated with server timestamp on registration.

## Docs
- ARCHITECTURE.md — users schema updated with `consent_given_at`, GDPR endpoints added to API routes, encryption decision section added
- README.md — privacy notice section added for self-hosters who share the app

## Test plan

- [ ] 144 tests pass, 0 warnings
- [ ] `DELETE /api/gdpr/erase` → 401 without token, 204 on success, login fails after, all data rows removed
- [ ] `GET /api/gdpr/export` → 401 without token, correct structure, no hashed_password, Content-Disposition header set
- [ ] Register without `consent_given` or with `consent_given: false` → 422
- [ ] `consent_given_at` attribute exists on User model
