### PR TITLE
perf: fix N+1 queries in sessions list endpoint (#129)

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -46,7 +46,7 @@ All tests live in `backend/tests/`. The suite uses a single in-memory SQLite dat
 | `test_measurements.py` | Body measurement CRUD, auth enforcement, full BIA formula application with impedance inputs |
 | `test_profile.py` | GET /api/profile structure and auth, PATCH updates (display_name, birth_year, sex, height_cm), unknown fields ignored, BIA falls back to profile height |
 | `test_progress.py` | Muscle balance, `epley_1rm` unit tests, strength progression (structure + daily best), volume over time, consistency heatmap, personal records |
-| `test_sessions.py` | Full workout session flow: start → log sets → end → list → get logs; edge cases (unknown session, already ended, 404) |
+| `test_sessions.py` | Full workout session flow: start → log sets → end → list → get logs; edge cases (unknown session, already ended, 404); N+1 query regression guard (asserts ≤2 SELECT statements on list endpoint) |
 | `test_stats.py` | Home stats structure, streak calculation (unit + UTC correctness), week bounds (UTC correctness) |
 
 ## conftest.py

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, ConfigDict
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from auth import get_current_user
@@ -69,29 +70,32 @@ def list_sessions(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    workouts = (
-        db.query(WorkoutSession)
+    rows = (
+        db.query(
+            WorkoutSession,
+            func.count(Log.id).label("set_count"),
+            func.coalesce(func.sum(Log.weight * Log.reps), 0.0).label("volume_kg"),
+        )
+        .outerjoin(Log, Log.session_id == WorkoutSession.id)
         .filter(
             WorkoutSession.user_id == current_user.id,
             WorkoutSession.ended_at.isnot(None),
         )
+        .group_by(WorkoutSession.id)
         .order_by(WorkoutSession.started_at.desc())
         .all()
     )
-    result = []
-    for w in workouts:
-        logs = db.query(Log).filter(Log.session_id == w.id).all()
-        result.append(
-            WorkoutSessionSummary(
-                id=w.id,
-                session=w.session,
-                started_at=w.started_at,
-                ended_at=w.ended_at,
-                set_count=len(logs),
-                volume_kg=sum(log.weight * log.reps for log in logs),
-            )
+    return [
+        WorkoutSessionSummary(
+            id=w.id,
+            session=w.session,
+            started_at=w.started_at,
+            ended_at=w.ended_at,
+            set_count=set_count,
+            volume_kg=float(volume_kg),
         )
-    return result
+        for w, set_count, volume_kg in rows
+    ]
 
 
 @router.get("/{session_id}/logs", response_model=list[SessionLogEntry])

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -132,6 +132,47 @@ def test_get_session_logs_nonexistent_session_returns_404(client: TestClient):
     assert resp.status_code == 404
 
 
+# ── N+1 regression (#129) ────────────────────────────────────────────────────
+
+
+def test_list_sessions_single_query(client: TestClient):
+    """GET /api/sessions must not fire a query per session (N+1 anti-pattern).
+
+    Seeds 5 completed sessions then counts SELECT statements issued during the
+    list request.  The current N+1 implementation fires 1 (sessions fetch) +
+    5 (one logs query per session) = 6 queries inside the handler, which exceeds
+    the budget of ≤2 (auth + one aggregated join).
+    """
+    from sqlalchemy import event
+
+    from database import engine
+
+    exercise_id = _first_exercise_id(client)
+    headers = _auth(client)
+
+    for _ in range(5):
+        s = _start(client)
+        _log_set(client, s["id"], exercise_id)
+        _log_set(client, s["id"], exercise_id)
+        client.patch(f"/api/sessions/{s['id']}/end", headers=headers)
+
+    query_count = 0
+
+    def _count(conn, cursor, statement, parameters, context, executemany):
+        nonlocal query_count
+        if statement.strip().upper().startswith("SELECT"):
+            query_count += 1
+
+    event.listen(engine, "before_cursor_execute", _count)
+    try:
+        resp = client.get("/api/sessions", headers=headers)
+    finally:
+        event.remove(engine, "before_cursor_execute", _count)
+
+    assert resp.status_code == 200
+    assert query_count <= 2, f"N+1 detected: {query_count} SELECT queries (expected ≤2)"
+
+
 # ── Full flow ─────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
GET /api/sessions fired 1+N SQL queries — one to fetch all sessions then one SELECT logs per session in a Python for-loop. With 50 sessions that was 51 round-trips.

Replaced the for-loop with a single outerjoin + func.count/func.sum/group_by. Query count drops from 1+N to 1 regardless of session count.

A before_cursor_execute listener test guards against regression: seeds 5 sessions and asserts ≤2 SELECT statements during the list request.

Closes #129 