### PR TITLE
perf: fix N+1 queries in personal records endpoint (#130)

### DIFF
--- a/backend/routers/progress.py
+++ b/backend/routers/progress.py
@@ -220,23 +220,33 @@ def personal_records(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    exercises = db.query(Exercise).order_by(Exercise.name).all()
-    prs = []
-    for exercise in exercises:
-        logs = (
-            _user_logs(db, current_user.id).filter(Log.exercise_id == exercise.id).all()
-        )
-        if not logs:
-            continue
-        best = max(logs, key=lambda log: epley_1rm(log.weight, log.reps))
-        prs.append(
+    rows = (
+        db.query(Log, Exercise)
+        .join(Exercise, Log.exercise_id == Exercise.id)
+        .join(WorkoutSession, Log.session_id == WorkoutSession.id)
+        .filter(WorkoutSession.user_id == current_user.id)
+        .all()
+    )
+
+    best: dict[int, tuple[Log, Exercise]] = {}
+    for log, exercise in rows:
+        e1rm = epley_1rm(log.weight, log.reps)
+        if exercise.id not in best or e1rm > epley_1rm(
+            best[exercise.id][0].weight, best[exercise.id][0].reps
+        ):
+            best[exercise.id] = (log, exercise)
+
+    return sorted(
+        [
             PersonalRecord(
                 exercise_id=exercise.id,
                 exercise_name=exercise.name,
-                weight=best.weight,
-                reps=best.reps,
-                estimated_1rm=round(epley_1rm(best.weight, best.reps), 2),
-                date=best.logged_at.date().isoformat(),
+                weight=log.weight,
+                reps=log.reps,
+                estimated_1rm=round(epley_1rm(log.weight, log.reps), 2),
+                date=log.logged_at.date().isoformat(),
             )
-        )
-    return prs
+            for log, exercise in best.values()
+        ],
+        key=lambda pr: pr.exercise_name,
+    )

--- a/backend/tests/test_progress.py
+++ b/backend/tests/test_progress.py
@@ -300,3 +300,42 @@ def test_prs_picks_best_set_per_exercise(client: TestClient):
     assert match["estimated_1rm"] >= 100.0
     assert "exercise_name" in match
     assert "date" in match
+
+
+# ── N+1 regression (#130) ─────────────────────────────────────────────────────
+
+
+def test_prs_single_query(client: TestClient):
+    """GET /api/progress/prs must not fire one query per exercise (N+1).
+
+    The current implementation fetches all exercises then calls _user_logs per
+    exercise in a loop.  With 30 exercises in the seed library the handler fires
+    31+ SELECT statements.  The fix uses a single joined query, so total SELECT
+    count must be ≤3 (auth + one aggregated join).
+    """
+    from sqlalchemy import event
+
+    from database import engine
+
+    headers = _auth(client)
+
+    # Seed logs across three exercises so N+1 is observable
+    exercises = client.get("/api/exercises?session=Push+A", headers=headers).json()
+    for ex in exercises[:3]:
+        _log_and_end(client, ex["id"], 60.0, 8)
+
+    query_count = 0
+
+    def _count(conn, cursor, statement, parameters, context, executemany):
+        nonlocal query_count
+        if statement.strip().upper().startswith("SELECT"):
+            query_count += 1
+
+    event.listen(engine, "before_cursor_execute", _count)
+    try:
+        resp = client.get("/api/progress/prs", headers=headers)
+    finally:
+        event.remove(engine, "before_cursor_execute", _count)
+
+    assert resp.status_code == 200
+    assert query_count <= 3, f"N+1 detected: {query_count} SELECT queries (expected ≤3)"


### PR DESCRIPTION
GET /api/progress/prs fetched all exercises then fired one log query per exercise in a loop — 31 queries with a 30-exercise library.

Replaced the loop with a single Log JOIN Exercise JOIN WorkoutSession query filtered by user_id, then grouped by exercise in Python to find the best 1RM. Query count drops from 1+N to 1 regardless of library size.

GET /api/progress/strength was reviewed and was already clean (2 queries).

Closes #130