### PR TITLE
perf: add database indexes on logs and body_measurements (#131)

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -35,6 +35,7 @@ All tests live in `backend/tests/`. The suite uses a single in-memory SQLite dat
 
 | File | What it covers |
 |---|---|
+| `test_indexes.py` | Schema index assertions: verifies that `logs.session_id`, `logs.exercise_id`, `workout_sessions.user_id`, `body_measurements.user_id`, and `cardio_entries.user_id` are indexed |
 | `test_admin.py` | Admin user management: list users, create, disable/enable, delete (with data cascade); 403 for non-admins, self-disable/delete blocked |
 | `test_auth.py` | Password hashing, login, registration validation (min length, consent required), JWT-protected endpoints, password change (wrong current → 400, short new → 422, success) |
 | `test_cardio.py` | Cardio entry logging, list, delete, activity validation, schema contract (no `session_id`) |

--- a/backend/alembic/versions/e2f9a3b7c1d5_add_indexes_on_logs_and_measurements.py
+++ b/backend/alembic/versions/e2f9a3b7c1d5_add_indexes_on_logs_and_measurements.py
@@ -1,0 +1,31 @@
+"""add indexes on logs and body_measurements
+
+Revision ID: e2f9a3b7c1d5
+Revises: d5e8f2a1b4c7
+Create Date: 2026-07-05
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "e2f9a3b7c1d5"
+down_revision: Union[str, Sequence[str], None] = "d5e8f2a1b4c7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index("ix_logs_session_id", "logs", ["session_id"])
+    op.create_index("ix_logs_exercise_id", "logs", ["exercise_id"])
+    op.create_index("ix_workout_sessions_user_id", "workout_sessions", ["user_id"])
+    op.create_index("ix_body_measurements_user_id", "body_measurements", ["user_id"])
+    op.create_index("ix_cardio_entries_user_id", "cardio_entries", ["user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_logs_session_id", table_name="logs")
+    op.drop_index("ix_logs_exercise_id", table_name="logs")
+    op.drop_index("ix_workout_sessions_user_id", table_name="workout_sessions")
+    op.drop_index("ix_body_measurements_user_id", table_name="body_measurements")
+    op.drop_index("ix_cardio_entries_user_id", table_name="cardio_entries")

--- a/backend/models/cardio.py
+++ b/backend/models/cardio.py
@@ -11,7 +11,7 @@ class CardioEntry(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     user_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("users.id"), nullable=False
+        Integer, ForeignKey("users.id"), nullable=False, index=True
     )
     activity: Mapped[str] = mapped_column(String, nullable=False)
     distance_m: Mapped[float | None] = mapped_column(Float)

--- a/backend/models/measurement.py
+++ b/backend/models/measurement.py
@@ -11,7 +11,7 @@ class BodyMeasurement(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     user_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("users.id"), nullable=False
+        Integer, ForeignKey("users.id"), nullable=False, index=True
     )
     recorded_at: Mapped[datetime] = mapped_column(TZDateTime, nullable=False)
 

--- a/backend/models/workout.py
+++ b/backend/models/workout.py
@@ -11,7 +11,7 @@ class WorkoutSession(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     user_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("users.id"), nullable=False
+        Integer, ForeignKey("users.id"), nullable=False, index=True
     )
     session: Mapped[str] = mapped_column(String, nullable=False)
     started_at: Mapped[datetime] = mapped_column(TZDateTime, nullable=False)
@@ -25,10 +25,10 @@ class Log(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     exercise_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("exercises.id"), nullable=False
+        Integer, ForeignKey("exercises.id"), nullable=False, index=True
     )
     session_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("workout_sessions.id"), nullable=False
+        Integer, ForeignKey("workout_sessions.id"), nullable=False, index=True
     )
     weight: Mapped[float] = mapped_column(Float, nullable=False)
     reps: Mapped[int] = mapped_column(Integer, nullable=False)

--- a/backend/tests/test_indexes.py
+++ b/backend/tests/test_indexes.py
@@ -11,7 +11,10 @@ from database import engine
 
 def _indexed_columns(table: str) -> set[str]:
     return {
-        col for idx in inspect(engine).get_indexes(table) for col in idx["column_names"]
+        col
+        for idx in inspect(engine).get_indexes(table)
+        for col in idx["column_names"]
+        if col is not None
     }
 
 

--- a/backend/tests/test_indexes.py
+++ b/backend/tests/test_indexes.py
@@ -1,0 +1,40 @@
+"""Schema index tests (#131).
+
+The test DB is built via Base.metadata.create_all so indexes must be declared
+on the models — not only in Alembic — to be picked up here.
+"""
+
+from sqlalchemy import inspect
+
+from database import engine
+
+
+def _indexed_columns(table: str) -> set[str]:
+    return {
+        col for idx in inspect(engine).get_indexes(table) for col in idx["column_names"]
+    }
+
+
+def test_logs_session_id_is_indexed():
+    """logs.session_id — used in every session detail and N+1 scan."""
+    assert "session_id" in _indexed_columns("logs")
+
+
+def test_logs_exercise_id_is_indexed():
+    """logs.exercise_id — used in strength progression and personal records."""
+    assert "exercise_id" in _indexed_columns("logs")
+
+
+def test_workout_sessions_user_id_is_indexed():
+    """workout_sessions.user_id — used in sessions list and all user-scoped joins."""
+    assert "user_id" in _indexed_columns("workout_sessions")
+
+
+def test_body_measurements_user_id_is_indexed():
+    """body_measurements.user_id — used in measurements list."""
+    assert "user_id" in _indexed_columns("body_measurements")
+
+
+def test_cardio_entries_user_id_is_indexed():
+    """cardio_entries.user_id — used in cardio list."""
+    assert "user_id" in _indexed_columns("cardio_entries")


### PR DESCRIPTION
No indexes existed on the high-traffic foreign-key columns. Every user-scoped query (sessions list, strength, PRs, cardio, measurements) was doing a full table scan.

Added index=True to logs.session_id, logs.exercise_id, workout_sessions.user_id, body_measurements.user_id, and cardio_entries.user_id in the SQLAlchemy models (so create_all picks them up in dev/tests) and a matching Alembic migration for existing deployments.

Closes #131