### PR TITLE
fix: handle alembic migration failures gracefully in entrypoint.sh (#…

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -39,6 +39,7 @@ All tests live in `backend/tests/`. The suite uses a single in-memory SQLite dat
 | `test_admin.py` | Admin user management: list users, create, disable/enable, delete (with data cascade); 403 for non-admins, self-disable/delete blocked |
 | `test_auth.py` | Password hashing, login, registration validation (min length, consent required), JWT-protected endpoints, password change (wrong current → 400, short new → 422, success) |
 | `test_cardio.py` | Cardio entry logging, list, delete, activity validation, schema contract (no `session_id`) |
+| `test_entrypoint.py` | entrypoint.sh behaviour: non-zero exit and clear error message to stderr when migration fails; uvicorn not invoked on failure, invoked on success |
 | `test_exercises.py` | Exercise list (session + search filters), exercise by ID, sessions list |
 | `test_gdpr.py` | Right to erasure (401, 204, cascade delete); data export (401, structure, no password hash, Content-Disposition header, workout sessions included) |
 | `test_formulas.py` | Body composition formula calculations (BMI, fat mass, lean mass, BMR, segmental values) — pure unit tests, no HTTP |

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/sh
 set -e
-alembic upgrade head
+
+echo "Running database migrations..."
+if ! alembic upgrade head; then
+    echo "ERROR: Database migration failed — the server will not start." >&2
+    echo "Check the migration output above for details." >&2
+    exit 1
+fi
+
+echo "Migrations complete. Starting server..."
 exec uvicorn main:app --host 0.0.0.0 --port 8000

--- a/backend/tests/test_entrypoint.py
+++ b/backend/tests/test_entrypoint.py
@@ -1,0 +1,62 @@
+"""entrypoint.sh behaviour tests (#133).
+
+Uses subprocess with fake alembic/uvicorn binaries injected via PATH so the
+real database is never touched.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).parent.parent
+
+
+def _run(tmp_path: Path, alembic_exit: int) -> subprocess.CompletedProcess:
+    fake_alembic = tmp_path / "alembic"
+    fake_alembic.write_text(f"#!/bin/sh\nexit {alembic_exit}\n")
+    fake_alembic.chmod(0o755)
+
+    marker = tmp_path / "uvicorn_called"
+    fake_uvicorn = tmp_path / "uvicorn"
+    fake_uvicorn.write_text(f"#!/bin/sh\ntouch {marker}\n")
+    fake_uvicorn.chmod(0o755)
+
+    env = {**os.environ, "PATH": f"{tmp_path}:{os.environ.get('PATH', '')}"}
+    return subprocess.run(
+        ["sh", "entrypoint.sh"],
+        cwd=BACKEND_DIR,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_entrypoint_exits_nonzero_when_migration_fails(tmp_path):
+    """A failing migration must produce a non-zero exit code."""
+    result = _run(tmp_path, alembic_exit=1)
+    assert result.returncode != 0
+
+
+def test_entrypoint_does_not_start_uvicorn_when_migration_fails(tmp_path):
+    """uvicorn must not be invoked when the migration fails."""
+    _run(tmp_path, alembic_exit=1)
+    assert not (tmp_path / "uvicorn_called").exists()
+
+
+def test_entrypoint_prints_error_message_when_migration_fails(tmp_path):
+    """A clear error message must appear when the migration fails.
+
+    The current entrypoint silently exits via set -e with no message —
+    this fails because combined stdout+stderr contains no 'error' context.
+    """
+    result = _run(tmp_path, alembic_exit=1)
+    combined = result.stdout + result.stderr
+    assert "error" in combined.lower() and "migration" in combined.lower(), (
+        f"No clear error message found.\nstdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+
+
+def test_entrypoint_starts_uvicorn_when_migration_succeeds(tmp_path):
+    """When migration succeeds, uvicorn must be invoked."""
+    _run(tmp_path, alembic_exit=0)
+    assert (tmp_path / "uvicorn_called").exists()


### PR DESCRIPTION
…133)

entrypoint.sh had set -e so uvicorn was already blocked on failure, but the script exited silently — no message in the logs to indicate what went wrong or why the container stopped.

Added explicit error handling: if alembic fails, a clear ERROR message is written to stderr before exiting 1. Added progress echoes so successful startup is also visible in container logs.

Closes #133