### PR TITLE
chore: add SQLAlchemy connection pool configuration (#134)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,12 @@ JWT_EXPIRE_DAYS=7
 # Mapped to the db_data Docker volume — do not change unless you know why.
 DATA_DIR=/app/data
 
+# Connection pool tuning — defaults are fine for a single-user self-hosted app.
+# Only change these if you observe "queue overflow" errors under concurrent load.
+DB_POOL_SIZE=5
+DB_MAX_OVERFLOW=10
+DB_POOL_TIMEOUT=30
+
 # ── Smart scale ingestion ─────────────────────────────────────────────────────
 # Used by scripts/scale_ingest.py — not required for the server itself.
 FITMAN_API_URL=http://localhost:8000

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -262,6 +262,9 @@ All configuration lives in `.env` at the project root. See `.env.example` for a 
 | `JWT_EXPIRE_DAYS` | | `7` | Token validity in days |
 | `DATA_DIR` | | `./data` | SQLite file location (`/app/data` in Docker) |
 | `CORS_ORIGINS` | | `http://localhost:3000` | Allowed frontend origins |
+| `DB_POOL_SIZE` | | `5` | SQLAlchemy connection pool size |
+| `DB_MAX_OVERFLOW` | | `10` | Max connections above pool size before blocking |
+| `DB_POOL_TIMEOUT` | | `30` | Seconds to wait for a connection before raising an error |
 
 User credentials are stored in the database. On first launch, visit `/setup` to create the admin account. `ADMIN_USERNAME` and `ADMIN_PASSWORD` are no longer used.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -39,6 +39,7 @@ All tests live in `backend/tests/`. The suite uses a single in-memory SQLite dat
 | `test_admin.py` | Admin user management: list users, create, disable/enable, delete (with data cascade); 403 for non-admins, self-disable/delete blocked |
 | `test_auth.py` | Password hashing, login, registration validation (min length, consent required), JWT-protected endpoints, password change (wrong current → 400, short new → 422, success) |
 | `test_cardio.py` | Cardio entry logging, list, delete, activity validation, schema contract (no `session_id`) |
+| `test_database_pool.py` | Connection pool configuration: verifies DB_POOL_SIZE, DB_MAX_OVERFLOW, DB_POOL_TIMEOUT env vars are read and applied; default values; uses a temp file-based SQLite URL (not :memory:) to exercise QueuePool |
 | `test_entrypoint.py` | entrypoint.sh behaviour: non-zero exit and clear error message to stderr when migration fails; uvicorn not invoked on failure, invoked on success |
 | `test_exercises.py` | Exercise list (session + search filters), exercise by ID, sessions list |
 | `test_gdpr.py` | Right to erasure (401, 204, cascade delete); data export (401, structure, no password hash, Content-Disposition header, workout sessions included) |

--- a/backend/database.py
+++ b/backend/database.py
@@ -13,10 +13,18 @@ os.makedirs(DATA_DIR, exist_ok=True)
 
 DATABASE_URL = f"sqlite:///{DATA_DIR}/fitman.db"
 
-engine = create_engine(
-    DATABASE_URL,
-    connect_args={"check_same_thread": False},
-)
+
+def _make_engine(url: str):
+    return create_engine(
+        url,
+        connect_args={"check_same_thread": False},
+        pool_size=int(os.getenv("DB_POOL_SIZE", "5")),
+        max_overflow=int(os.getenv("DB_MAX_OVERFLOW", "10")),
+        pool_timeout=int(os.getenv("DB_POOL_TIMEOUT", "30")),
+    )
+
+
+engine = _make_engine(DATABASE_URL)
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 

--- a/backend/tests/test_database_pool.py
+++ b/backend/tests/test_database_pool.py
@@ -1,0 +1,85 @@
+"""Connection pool configuration tests (#134).
+
+Tests call _make_engine() directly with a temp file-based SQLite URL
+(not :memory:, which uses StaticPool and doesn't accept pool_size args)
+and monkeypatched env vars so the module-level singleton engine is never
+touched.
+"""
+
+from pathlib import Path
+
+
+def _url(tmp_path: Path) -> str:
+    return f"sqlite:///{tmp_path}/test.db"
+
+
+def test_pool_size_defaults_to_five(monkeypatch, tmp_path):
+    """Without DB_POOL_SIZE the pool must default to 5."""
+    monkeypatch.delenv("DB_POOL_SIZE", raising=False)
+    from database import _make_engine
+
+    e = _make_engine(_url(tmp_path))
+    try:
+        assert e.pool.size() == 5
+    finally:
+        e.dispose()
+
+
+def test_pool_size_is_configurable(monkeypatch, tmp_path):
+    """DB_POOL_SIZE env var must set the pool size."""
+    monkeypatch.setenv("DB_POOL_SIZE", "3")
+    from database import _make_engine
+
+    e = _make_engine(_url(tmp_path))
+    try:
+        assert e.pool.size() == 3
+    finally:
+        e.dispose()
+
+
+def test_max_overflow_defaults_to_ten(monkeypatch, tmp_path):
+    """Without DB_MAX_OVERFLOW the pool must default to 10."""
+    monkeypatch.delenv("DB_MAX_OVERFLOW", raising=False)
+    from database import _make_engine
+
+    e = _make_engine(_url(tmp_path))
+    try:
+        assert e.pool._max_overflow == 10
+    finally:
+        e.dispose()
+
+
+def test_max_overflow_is_configurable(monkeypatch, tmp_path):
+    """DB_MAX_OVERFLOW env var must set the pool max overflow."""
+    monkeypatch.setenv("DB_MAX_OVERFLOW", "2")
+    from database import _make_engine
+
+    e = _make_engine(_url(tmp_path))
+    try:
+        assert e.pool._max_overflow == 2
+    finally:
+        e.dispose()
+
+
+def test_pool_timeout_defaults_to_thirty(monkeypatch, tmp_path):
+    """Without DB_POOL_TIMEOUT the pool timeout must default to 30 seconds."""
+    monkeypatch.delenv("DB_POOL_TIMEOUT", raising=False)
+    from database import _make_engine
+
+    e = _make_engine(_url(tmp_path))
+    try:
+        assert e.pool._timeout == 30
+    finally:
+        e.dispose()
+
+
+def test_pool_timeout_is_configurable(monkeypatch, tmp_path):
+    """DB_POOL_TIMEOUT env var must set the pool timeout in seconds."""
+    monkeypatch.setenv("DB_POOL_TIMEOUT", "15")
+    from database import _make_engine
+
+    e = _make_engine(_url(tmp_path))
+    try:
+        assert e.pool._timeout == 15
+    finally:
+        e.dispose()


### PR DESCRIPTION
The engine was created with hardcoded defaults and no way to tune pool behaviour without touching code.

Extracted _make_engine() factory that reads DB_POOL_SIZE (default 5), DB_MAX_OVERFLOW (default 10), and DB_POOL_TIMEOUT (default 30) from env vars. Documented the new variables in .env.example and ARCHITECTURE.md.

Closes #134