### PR TITLE
M18: Performance & query optimisation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,12 @@ JWT_EXPIRE_DAYS=7
 # Mapped to the db_data Docker volume — do not change unless you know why.
 DATA_DIR=/app/data
 
+# Connection pool tuning — defaults are fine for a single-user self-hosted app.
+# Only change these if you observe "queue overflow" errors under concurrent load.
+DB_POOL_SIZE=5
+DB_MAX_OVERFLOW=10
+DB_POOL_TIMEOUT=30
+
 # ── Smart scale ingestion ─────────────────────────────────────────────────────
 # Used by scripts/scale_ingest.py — not required for the server itself.
 FITMAN_API_URL=http://localhost:8000

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -262,6 +262,9 @@ All configuration lives in `.env` at the project root. See `.env.example` for a 
 | `JWT_EXPIRE_DAYS` | | `7` | Token validity in days |
 | `DATA_DIR` | | `./data` | SQLite file location (`/app/data` in Docker) |
 | `CORS_ORIGINS` | | `http://localhost:3000` | Allowed frontend origins |
+| `DB_POOL_SIZE` | | `5` | SQLAlchemy connection pool size |
+| `DB_MAX_OVERFLOW` | | `10` | Max connections above pool size before blocking |
+| `DB_POOL_TIMEOUT` | | `30` | Seconds to wait for a connection before raising an error |
 
 User credentials are stored in the database. On first launch, visit `/setup` to create the admin account. `ADMIN_USERNAME` and `ADMIN_PASSWORD` are no longer used.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -39,6 +39,7 @@ All tests live in `backend/tests/`. The suite uses a single in-memory SQLite dat
 | `test_admin.py` | Admin user management: list users, create, disable/enable, delete (with data cascade); 403 for non-admins, self-disable/delete blocked |
 | `test_auth.py` | Password hashing, login, registration validation (min length, consent required), JWT-protected endpoints, password change (wrong current → 400, short new → 422, success) |
 | `test_cardio.py` | Cardio entry logging, list, delete, activity validation, schema contract (no `session_id`) |
+| `test_entrypoint.py` | entrypoint.sh behaviour: non-zero exit and clear error message to stderr when migration fails; uvicorn not invoked on failure, invoked on success |
 | `test_exercises.py` | Exercise list (session + search filters), exercise by ID, sessions list |
 | `test_gdpr.py` | Right to erasure (401, 204, cascade delete); data export (401, structure, no password hash, Content-Disposition header, workout sessions included) |
 | `test_formulas.py` | Body composition formula calculations (BMI, fat mass, lean mass, BMR, segmental values) — pure unit tests, no HTTP |

--- a/TESTING.md
+++ b/TESTING.md
@@ -46,7 +46,7 @@ All tests live in `backend/tests/`. The suite uses a single in-memory SQLite dat
 | `test_measurements.py` | Body measurement CRUD, auth enforcement, full BIA formula application with impedance inputs |
 | `test_profile.py` | GET /api/profile structure and auth, PATCH updates (display_name, birth_year, sex, height_cm), unknown fields ignored, BIA falls back to profile height |
 | `test_progress.py` | Muscle balance, `epley_1rm` unit tests, strength progression (structure + daily best), volume over time, consistency heatmap, personal records |
-| `test_sessions.py` | Full workout session flow: start → log sets → end → list → get logs; edge cases (unknown session, already ended, 404) |
+| `test_sessions.py` | Full workout session flow: start → log sets → end → list → get logs; edge cases (unknown session, already ended, 404); N+1 query regression guard (asserts ≤2 SELECT statements on list endpoint) |
 | `test_stats.py` | Home stats structure, streak calculation (unit + UTC correctness), week bounds (UTC correctness) |
 
 ## conftest.py

--- a/TESTING.md
+++ b/TESTING.md
@@ -35,6 +35,7 @@ All tests live in `backend/tests/`. The suite uses a single in-memory SQLite dat
 
 | File | What it covers |
 |---|---|
+| `test_indexes.py` | Schema index assertions: verifies that `logs.session_id`, `logs.exercise_id`, `workout_sessions.user_id`, `body_measurements.user_id`, and `cardio_entries.user_id` are indexed |
 | `test_admin.py` | Admin user management: list users, create, disable/enable, delete (with data cascade); 403 for non-admins, self-disable/delete blocked |
 | `test_auth.py` | Password hashing, login, registration validation (min length, consent required), JWT-protected endpoints, password change (wrong current → 400, short new → 422, success) |
 | `test_cardio.py` | Cardio entry logging, list, delete, activity validation, schema contract (no `session_id`) |

--- a/TESTING.md
+++ b/TESTING.md
@@ -39,6 +39,7 @@ All tests live in `backend/tests/`. The suite uses a single in-memory SQLite dat
 | `test_admin.py` | Admin user management: list users, create, disable/enable, delete (with data cascade); 403 for non-admins, self-disable/delete blocked |
 | `test_auth.py` | Password hashing, login, registration validation (min length, consent required), JWT-protected endpoints, password change (wrong current → 400, short new → 422, success) |
 | `test_cardio.py` | Cardio entry logging, list, delete, activity validation, schema contract (no `session_id`) |
+| `test_database_pool.py` | Connection pool configuration: verifies DB_POOL_SIZE, DB_MAX_OVERFLOW, DB_POOL_TIMEOUT env vars are read and applied; default values; uses a temp file-based SQLite URL (not :memory:) to exercise QueuePool |
 | `test_entrypoint.py` | entrypoint.sh behaviour: non-zero exit and clear error message to stderr when migration fails; uvicorn not invoked on failure, invoked on success |
 | `test_exercises.py` | Exercise list (session + search filters), exercise by ID, sessions list |
 | `test_gdpr.py` | Right to erasure (401, 204, cascade delete); data export (401, structure, no password hash, Content-Disposition header, workout sessions included) |

--- a/backend/alembic/versions/e2f9a3b7c1d5_add_indexes_on_logs_and_measurements.py
+++ b/backend/alembic/versions/e2f9a3b7c1d5_add_indexes_on_logs_and_measurements.py
@@ -1,0 +1,31 @@
+"""add indexes on logs and body_measurements
+
+Revision ID: e2f9a3b7c1d5
+Revises: d5e8f2a1b4c7
+Create Date: 2026-07-05
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "e2f9a3b7c1d5"
+down_revision: Union[str, Sequence[str], None] = "d5e8f2a1b4c7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index("ix_logs_session_id", "logs", ["session_id"])
+    op.create_index("ix_logs_exercise_id", "logs", ["exercise_id"])
+    op.create_index("ix_workout_sessions_user_id", "workout_sessions", ["user_id"])
+    op.create_index("ix_body_measurements_user_id", "body_measurements", ["user_id"])
+    op.create_index("ix_cardio_entries_user_id", "cardio_entries", ["user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_logs_session_id", table_name="logs")
+    op.drop_index("ix_logs_exercise_id", table_name="logs")
+    op.drop_index("ix_workout_sessions_user_id", table_name="workout_sessions")
+    op.drop_index("ix_body_measurements_user_id", table_name="body_measurements")
+    op.drop_index("ix_cardio_entries_user_id", table_name="cardio_entries")

--- a/backend/database.py
+++ b/backend/database.py
@@ -13,10 +13,18 @@ os.makedirs(DATA_DIR, exist_ok=True)
 
 DATABASE_URL = f"sqlite:///{DATA_DIR}/fitman.db"
 
-engine = create_engine(
-    DATABASE_URL,
-    connect_args={"check_same_thread": False},
-)
+
+def _make_engine(url: str):
+    return create_engine(
+        url,
+        connect_args={"check_same_thread": False},
+        pool_size=int(os.getenv("DB_POOL_SIZE", "5")),
+        max_overflow=int(os.getenv("DB_MAX_OVERFLOW", "10")),
+        pool_timeout=int(os.getenv("DB_POOL_TIMEOUT", "30")),
+    )
+
+
+engine = _make_engine(DATABASE_URL)
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/sh
 set -e
-alembic upgrade head
+
+echo "Running database migrations..."
+if ! alembic upgrade head; then
+    echo "ERROR: Database migration failed — the server will not start." >&2
+    echo "Check the migration output above for details." >&2
+    exit 1
+fi
+
+echo "Migrations complete. Starting server..."
 exec uvicorn main:app --host 0.0.0.0 --port 8000

--- a/backend/models/cardio.py
+++ b/backend/models/cardio.py
@@ -11,7 +11,7 @@ class CardioEntry(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     user_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("users.id"), nullable=False
+        Integer, ForeignKey("users.id"), nullable=False, index=True
     )
     activity: Mapped[str] = mapped_column(String, nullable=False)
     distance_m: Mapped[float | None] = mapped_column(Float)

--- a/backend/models/measurement.py
+++ b/backend/models/measurement.py
@@ -11,7 +11,7 @@ class BodyMeasurement(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     user_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("users.id"), nullable=False
+        Integer, ForeignKey("users.id"), nullable=False, index=True
     )
     recorded_at: Mapped[datetime] = mapped_column(TZDateTime, nullable=False)
 

--- a/backend/models/workout.py
+++ b/backend/models/workout.py
@@ -11,7 +11,7 @@ class WorkoutSession(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     user_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("users.id"), nullable=False
+        Integer, ForeignKey("users.id"), nullable=False, index=True
     )
     session: Mapped[str] = mapped_column(String, nullable=False)
     started_at: Mapped[datetime] = mapped_column(TZDateTime, nullable=False)
@@ -25,10 +25,10 @@ class Log(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     exercise_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("exercises.id"), nullable=False
+        Integer, ForeignKey("exercises.id"), nullable=False, index=True
     )
     session_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("workout_sessions.id"), nullable=False
+        Integer, ForeignKey("workout_sessions.id"), nullable=False, index=True
     )
     weight: Mapped[float] = mapped_column(Float, nullable=False)
     reps: Mapped[int] = mapped_column(Integer, nullable=False)

--- a/backend/routers/progress.py
+++ b/backend/routers/progress.py
@@ -220,23 +220,33 @@ def personal_records(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    exercises = db.query(Exercise).order_by(Exercise.name).all()
-    prs = []
-    for exercise in exercises:
-        logs = (
-            _user_logs(db, current_user.id).filter(Log.exercise_id == exercise.id).all()
-        )
-        if not logs:
-            continue
-        best = max(logs, key=lambda log: epley_1rm(log.weight, log.reps))
-        prs.append(
+    rows = (
+        db.query(Log, Exercise)
+        .join(Exercise, Log.exercise_id == Exercise.id)
+        .join(WorkoutSession, Log.session_id == WorkoutSession.id)
+        .filter(WorkoutSession.user_id == current_user.id)
+        .all()
+    )
+
+    best: dict[int, tuple[Log, Exercise]] = {}
+    for log, exercise in rows:
+        e1rm = epley_1rm(log.weight, log.reps)
+        if exercise.id not in best or e1rm > epley_1rm(
+            best[exercise.id][0].weight, best[exercise.id][0].reps
+        ):
+            best[exercise.id] = (log, exercise)
+
+    return sorted(
+        [
             PersonalRecord(
                 exercise_id=exercise.id,
                 exercise_name=exercise.name,
-                weight=best.weight,
-                reps=best.reps,
-                estimated_1rm=round(epley_1rm(best.weight, best.reps), 2),
-                date=best.logged_at.date().isoformat(),
+                weight=log.weight,
+                reps=log.reps,
+                estimated_1rm=round(epley_1rm(log.weight, log.reps), 2),
+                date=log.logged_at.date().isoformat(),
             )
-        )
-    return prs
+            for log, exercise in best.values()
+        ],
+        key=lambda pr: pr.exercise_name,
+    )

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, ConfigDict
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from auth import get_current_user
@@ -69,29 +70,32 @@ def list_sessions(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    workouts = (
-        db.query(WorkoutSession)
+    rows = (
+        db.query(
+            WorkoutSession,
+            func.count(Log.id).label("set_count"),
+            func.coalesce(func.sum(Log.weight * Log.reps), 0.0).label("volume_kg"),
+        )
+        .outerjoin(Log, Log.session_id == WorkoutSession.id)
         .filter(
             WorkoutSession.user_id == current_user.id,
             WorkoutSession.ended_at.isnot(None),
         )
+        .group_by(WorkoutSession.id)
         .order_by(WorkoutSession.started_at.desc())
         .all()
     )
-    result = []
-    for w in workouts:
-        logs = db.query(Log).filter(Log.session_id == w.id).all()
-        result.append(
-            WorkoutSessionSummary(
-                id=w.id,
-                session=w.session,
-                started_at=w.started_at,
-                ended_at=w.ended_at,
-                set_count=len(logs),
-                volume_kg=sum(log.weight * log.reps for log in logs),
-            )
+    return [
+        WorkoutSessionSummary(
+            id=w.id,
+            session=w.session,
+            started_at=w.started_at,
+            ended_at=w.ended_at,
+            set_count=set_count,
+            volume_kg=float(volume_kg),
         )
-    return result
+        for w, set_count, volume_kg in rows
+    ]
 
 
 @router.get("/{session_id}/logs", response_model=list[SessionLogEntry])

--- a/backend/tests/test_database_pool.py
+++ b/backend/tests/test_database_pool.py
@@ -1,0 +1,85 @@
+"""Connection pool configuration tests (#134).
+
+Tests call _make_engine() directly with a temp file-based SQLite URL
+(not :memory:, which uses StaticPool and doesn't accept pool_size args)
+and monkeypatched env vars so the module-level singleton engine is never
+touched.
+"""
+
+from pathlib import Path
+
+
+def _url(tmp_path: Path) -> str:
+    return f"sqlite:///{tmp_path}/test.db"
+
+
+def test_pool_size_defaults_to_five(monkeypatch, tmp_path):
+    """Without DB_POOL_SIZE the pool must default to 5."""
+    monkeypatch.delenv("DB_POOL_SIZE", raising=False)
+    from database import _make_engine
+
+    e = _make_engine(_url(tmp_path))
+    try:
+        assert e.pool.size() == 5
+    finally:
+        e.dispose()
+
+
+def test_pool_size_is_configurable(monkeypatch, tmp_path):
+    """DB_POOL_SIZE env var must set the pool size."""
+    monkeypatch.setenv("DB_POOL_SIZE", "3")
+    from database import _make_engine
+
+    e = _make_engine(_url(tmp_path))
+    try:
+        assert e.pool.size() == 3
+    finally:
+        e.dispose()
+
+
+def test_max_overflow_defaults_to_ten(monkeypatch, tmp_path):
+    """Without DB_MAX_OVERFLOW the pool must default to 10."""
+    monkeypatch.delenv("DB_MAX_OVERFLOW", raising=False)
+    from database import _make_engine
+
+    e = _make_engine(_url(tmp_path))
+    try:
+        assert e.pool._max_overflow == 10
+    finally:
+        e.dispose()
+
+
+def test_max_overflow_is_configurable(monkeypatch, tmp_path):
+    """DB_MAX_OVERFLOW env var must set the pool max overflow."""
+    monkeypatch.setenv("DB_MAX_OVERFLOW", "2")
+    from database import _make_engine
+
+    e = _make_engine(_url(tmp_path))
+    try:
+        assert e.pool._max_overflow == 2
+    finally:
+        e.dispose()
+
+
+def test_pool_timeout_defaults_to_thirty(monkeypatch, tmp_path):
+    """Without DB_POOL_TIMEOUT the pool timeout must default to 30 seconds."""
+    monkeypatch.delenv("DB_POOL_TIMEOUT", raising=False)
+    from database import _make_engine
+
+    e = _make_engine(_url(tmp_path))
+    try:
+        assert e.pool._timeout == 30
+    finally:
+        e.dispose()
+
+
+def test_pool_timeout_is_configurable(monkeypatch, tmp_path):
+    """DB_POOL_TIMEOUT env var must set the pool timeout in seconds."""
+    monkeypatch.setenv("DB_POOL_TIMEOUT", "15")
+    from database import _make_engine
+
+    e = _make_engine(_url(tmp_path))
+    try:
+        assert e.pool._timeout == 15
+    finally:
+        e.dispose()

--- a/backend/tests/test_entrypoint.py
+++ b/backend/tests/test_entrypoint.py
@@ -1,0 +1,62 @@
+"""entrypoint.sh behaviour tests (#133).
+
+Uses subprocess with fake alembic/uvicorn binaries injected via PATH so the
+real database is never touched.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).parent.parent
+
+
+def _run(tmp_path: Path, alembic_exit: int) -> subprocess.CompletedProcess:
+    fake_alembic = tmp_path / "alembic"
+    fake_alembic.write_text(f"#!/bin/sh\nexit {alembic_exit}\n")
+    fake_alembic.chmod(0o755)
+
+    marker = tmp_path / "uvicorn_called"
+    fake_uvicorn = tmp_path / "uvicorn"
+    fake_uvicorn.write_text(f"#!/bin/sh\ntouch {marker}\n")
+    fake_uvicorn.chmod(0o755)
+
+    env = {**os.environ, "PATH": f"{tmp_path}:{os.environ.get('PATH', '')}"}
+    return subprocess.run(
+        ["sh", "entrypoint.sh"],
+        cwd=BACKEND_DIR,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_entrypoint_exits_nonzero_when_migration_fails(tmp_path):
+    """A failing migration must produce a non-zero exit code."""
+    result = _run(tmp_path, alembic_exit=1)
+    assert result.returncode != 0
+
+
+def test_entrypoint_does_not_start_uvicorn_when_migration_fails(tmp_path):
+    """uvicorn must not be invoked when the migration fails."""
+    _run(tmp_path, alembic_exit=1)
+    assert not (tmp_path / "uvicorn_called").exists()
+
+
+def test_entrypoint_prints_error_message_when_migration_fails(tmp_path):
+    """A clear error message must appear when the migration fails.
+
+    The current entrypoint silently exits via set -e with no message —
+    this fails because combined stdout+stderr contains no 'error' context.
+    """
+    result = _run(tmp_path, alembic_exit=1)
+    combined = result.stdout + result.stderr
+    assert "error" in combined.lower() and "migration" in combined.lower(), (
+        f"No clear error message found.\nstdout: {result.stdout!r}\nstderr: {result.stderr!r}"
+    )
+
+
+def test_entrypoint_starts_uvicorn_when_migration_succeeds(tmp_path):
+    """When migration succeeds, uvicorn must be invoked."""
+    _run(tmp_path, alembic_exit=0)
+    assert (tmp_path / "uvicorn_called").exists()

--- a/backend/tests/test_indexes.py
+++ b/backend/tests/test_indexes.py
@@ -11,7 +11,10 @@ from database import engine
 
 def _indexed_columns(table: str) -> set[str]:
     return {
-        col for idx in inspect(engine).get_indexes(table) for col in idx["column_names"]
+        col
+        for idx in inspect(engine).get_indexes(table)
+        for col in idx["column_names"]
+        if col is not None
     }
 
 

--- a/backend/tests/test_indexes.py
+++ b/backend/tests/test_indexes.py
@@ -1,0 +1,40 @@
+"""Schema index tests (#131).
+
+The test DB is built via Base.metadata.create_all so indexes must be declared
+on the models — not only in Alembic — to be picked up here.
+"""
+
+from sqlalchemy import inspect
+
+from database import engine
+
+
+def _indexed_columns(table: str) -> set[str]:
+    return {
+        col for idx in inspect(engine).get_indexes(table) for col in idx["column_names"]
+    }
+
+
+def test_logs_session_id_is_indexed():
+    """logs.session_id — used in every session detail and N+1 scan."""
+    assert "session_id" in _indexed_columns("logs")
+
+
+def test_logs_exercise_id_is_indexed():
+    """logs.exercise_id — used in strength progression and personal records."""
+    assert "exercise_id" in _indexed_columns("logs")
+
+
+def test_workout_sessions_user_id_is_indexed():
+    """workout_sessions.user_id — used in sessions list and all user-scoped joins."""
+    assert "user_id" in _indexed_columns("workout_sessions")
+
+
+def test_body_measurements_user_id_is_indexed():
+    """body_measurements.user_id — used in measurements list."""
+    assert "user_id" in _indexed_columns("body_measurements")
+
+
+def test_cardio_entries_user_id_is_indexed():
+    """cardio_entries.user_id — used in cardio list."""
+    assert "user_id" in _indexed_columns("cardio_entries")

--- a/backend/tests/test_progress.py
+++ b/backend/tests/test_progress.py
@@ -300,3 +300,42 @@ def test_prs_picks_best_set_per_exercise(client: TestClient):
     assert match["estimated_1rm"] >= 100.0
     assert "exercise_name" in match
     assert "date" in match
+
+
+# ── N+1 regression (#130) ─────────────────────────────────────────────────────
+
+
+def test_prs_single_query(client: TestClient):
+    """GET /api/progress/prs must not fire one query per exercise (N+1).
+
+    The current implementation fetches all exercises then calls _user_logs per
+    exercise in a loop.  With 30 exercises in the seed library the handler fires
+    31+ SELECT statements.  The fix uses a single joined query, so total SELECT
+    count must be ≤3 (auth + one aggregated join).
+    """
+    from sqlalchemy import event
+
+    from database import engine
+
+    headers = _auth(client)
+
+    # Seed logs across three exercises so N+1 is observable
+    exercises = client.get("/api/exercises?session=Push+A", headers=headers).json()
+    for ex in exercises[:3]:
+        _log_and_end(client, ex["id"], 60.0, 8)
+
+    query_count = 0
+
+    def _count(conn, cursor, statement, parameters, context, executemany):
+        nonlocal query_count
+        if statement.strip().upper().startswith("SELECT"):
+            query_count += 1
+
+    event.listen(engine, "before_cursor_execute", _count)
+    try:
+        resp = client.get("/api/progress/prs", headers=headers)
+    finally:
+        event.remove(engine, "before_cursor_execute", _count)
+
+    assert resp.status_code == 200
+    assert query_count <= 3, f"N+1 detected: {query_count} SELECT queries (expected ≤3)"

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -132,6 +132,47 @@ def test_get_session_logs_nonexistent_session_returns_404(client: TestClient):
     assert resp.status_code == 404
 
 
+# ── N+1 regression (#129) ────────────────────────────────────────────────────
+
+
+def test_list_sessions_single_query(client: TestClient):
+    """GET /api/sessions must not fire a query per session (N+1 anti-pattern).
+
+    Seeds 5 completed sessions then counts SELECT statements issued during the
+    list request.  The current N+1 implementation fires 1 (sessions fetch) +
+    5 (one logs query per session) = 6 queries inside the handler, which exceeds
+    the budget of ≤2 (auth + one aggregated join).
+    """
+    from sqlalchemy import event
+
+    from database import engine
+
+    exercise_id = _first_exercise_id(client)
+    headers = _auth(client)
+
+    for _ in range(5):
+        s = _start(client)
+        _log_set(client, s["id"], exercise_id)
+        _log_set(client, s["id"], exercise_id)
+        client.patch(f"/api/sessions/{s['id']}/end", headers=headers)
+
+    query_count = 0
+
+    def _count(conn, cursor, statement, parameters, context, executemany):
+        nonlocal query_count
+        if statement.strip().upper().startswith("SELECT"):
+            query_count += 1
+
+    event.listen(engine, "before_cursor_execute", _count)
+    try:
+        resp = client.get("/api/sessions", headers=headers)
+    finally:
+        event.remove(engine, "before_cursor_execute", _count)
+
+    assert resp.status_code == 200
+    assert query_count <= 2, f"N+1 detected: {query_count} SELECT queries (expected ≤2)"
+
+
 # ── Full flow ─────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## M18 — Performance & Query Optimisation

Five issues addressing query efficiency, schema indexing, startup robustness,
and connection pool configurability.

Closes #129 
Closes #130 
Closes #131 
Closes #133 
Closes #134 

### What changed

**#129 — Fix N+1 queries in sessions list endpoint**
`GET /api/sessions` was firing one `SELECT logs` per session in a Python
for-loop (51 queries with 50 sessions). Replaced with a single aggregated
`outerjoin + func.count/func.sum/group_by`. Query count is now constant
regardless of session history. Regression guard added: a query-counter test
asserts ≤2 SELECT statements on the endpoint.

**#130 — Fix N+1 queries in personal records endpoint**
`GET /api/progress/prs` fetched all exercises then fired a separate log query
per exercise (31 queries for a 30-exercise library). Replaced with a single
`Log JOIN Exercise JOIN WorkoutSession` query filtered by user, grouped by
exercise in Python. `GET /api/progress/strength` was reviewed and was already
clean. Regression guard: asserts ≤3 SELECT statements.

**#131 — Add database indexes on high-traffic columns**
No indexes existed on any foreign-key columns. Added `index=True` to
`logs.session_id`, `logs.exercise_id`, `workout_sessions.user_id`,
`body_measurements.user_id`, and `cardio_entries.user_id` in the SQLAlchemy
models (picked up by `create_all` in dev/tests) plus a matching Alembic
migration for existing deployments. Five index assertion tests added.

**#133 — Graceful alembic failure handling in entrypoint.sh**
`entrypoint.sh` had `set -e` so uvicorn was already blocked on migration
failure, but the container exited silently with no message. Added explicit
error handling: on failure a clear `ERROR: Database migration failed` message
is written to stderr before exit 1. Also added progress echoes for successful
startup. Tested with fake alembic/uvicorn binaries injected via PATH.

**#134 — SQLAlchemy connection pool configuration**
The engine had hardcoded pool defaults with no way to tune without a code
change. Extracted `_make_engine()` factory reading `DB_POOL_SIZE` (default 5),
`DB_MAX_OVERFLOW` (default 10), and `DB_POOL_TIMEOUT` (default 30) from env
vars. Documented in `.env.example` and `ARCHITECTURE.md`.

### Test suite
161 passing, 0 warnings. ruff + mypy clean.

### No breaking changes
All changes are internal. No API contract changes, no migration destructive
steps, no env var renames.
