### PR TITLE
M19: PostgreSQL migration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,9 +15,9 @@ JWT_EXPIRE_DAYS=7
 # ADMIN_USERNAME and ADMIN_PASSWORD are no longer used.
 
 # ── Database ──────────────────────────────────────────────────────────────────
-# Path inside the container where the SQLite file is stored.
-# Mapped to the db_data Docker volume — do not change unless you know why.
-DATA_DIR=/app/data
+# PostgreSQL connection string. In Docker Compose the hostname is "postgres"
+# (the service name). For local dev outside Docker use localhost.
+DATABASE_URL=postgresql://fitman:fitman@postgres:5432/fitman
 
 # Connection pool tuning — defaults are fine for a single-user self-hosted app.
 # Only change these if you observe "queue overflow" errors under concurrent load.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,20 +23,6 @@ jobs:
   backend:
     name: Backend quality
     runs-on: self-hosted
-    services:
-      postgres:
-        image: postgres:16
-        env:
-          POSTGRES_DB: fitman_test
-          POSTGRES_USER: fitman
-          POSTGRES_PASSWORD: fitman
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 10
     defaults:
       run:
         working-directory: backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,20 @@ jobs:
   backend:
     name: Backend quality
     runs-on: self-hosted
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: fitman_test
+          POSTGRES_USER: fitman
+          POSTGRES_PASSWORD: fitman
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     defaults:
       run:
         working-directory: backend
@@ -46,9 +60,7 @@ jobs:
         run: .venv/bin/pytest tests/ -v --cov=. --cov-report=term-missing --cov-fail-under=80
         env:
           SECRET_KEY: ci-test-secret-key-for-ci-only-not-for-production
-          ADMIN_USERNAME: testuser
-          ADMIN_PASSWORD: testpass
-          DATA_DIR: /tmp/fitman_test
+          DATABASE_URL: postgresql://fitman:fitman@localhost:5432/fitman_test
 
   docker:
     name: Docker production build
@@ -60,7 +72,6 @@ jobs:
       - name: Create stub .env for build
         run: |
           echo "SECRET_KEY=ci_placeholder_key" >> .env
-          echo "ADMIN_USERNAME=ci" >> .env
-          echo "ADMIN_PASSWORD=ci" >> .env
+          echo "DATABASE_URL=postgresql://fitman:fitman@postgres:5432/fitman" >> .env
       - name: Build production images
         run: docker compose -f docker-compose.prod.yml build

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -39,11 +39,12 @@ Fitman is a two-service web application: a Python REST API and a React single-pa
 - In production: built to static files and served by nginx
 - In development: Vite dev server on port `5173` with `/api` proxy to backend
 
-### Database — SQLite
+### Database — PostgreSQL 16
 
-- Single file (`fitman.db`) stored in a Docker volume (`db_data`)
-- Easy to back up: just copy the file
-- Sufficient for a single-user app — no separate database server needed
+- Runs as a `postgres:16` Docker service with a named volume (`db_data`)
+- Supports concurrent writes — required for multi-user deployment
+- Accessed by the backend via `DATABASE_URL` in `.env`
+- Schema managed by Alembic; migrations run automatically on container start
 
 ## Directory structure
 
@@ -88,8 +89,8 @@ Fitman/
 │   ├── Dockerfile           # Dev only: Vite dev server
 │   └── package.json
 │
-├── docker-compose.yml       # Development: Vite dev server + backend
-├── docker-compose.prod.yml  # Production: nginx static build + backend
+├── docker-compose.yml       # Development: Vite dev server + backend + postgres
+├── docker-compose.prod.yml  # Production: nginx static build + backend + postgres
 ├── .env                     # Secrets and config — never committed (gitignored)
 ├── .env.example             # Template documenting all variables
 ├── README.md
@@ -259,8 +260,8 @@ All configuration lives in `.env` at the project root. See `.env.example` for a 
 | Variable | Required | Default | Description |
 |---|---|---|---|
 | `SECRET_KEY` | ✅ | — | Random string for signing JWT tokens. Changing it invalidates all sessions. |
+| `DATABASE_URL` | ✅ | — | PostgreSQL connection string, e.g. `postgresql://fitman:fitman@postgres:5432/fitman` |
 | `JWT_EXPIRE_DAYS` | | `7` | Token validity in days |
-| `DATA_DIR` | | `./data` | SQLite file location (`/app/data` in Docker) |
 | `CORS_ORIGINS` | | `http://localhost:3000` | Allowed frontend origins |
 | `DB_POOL_SIZE` | | `5` | SQLAlchemy connection pool size |
 | `DB_MAX_OVERFLOW` | | `10` | Max connections above pool size before blocking |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -15,8 +15,8 @@ Fitman is a two-service web application: a Python REST API and a React single-pa
                          │   │   proxy)    │   └───────┬───────┘  │
                          │   └─────────────┘           │           │
                          │                     ┌───────▼───────┐  │
-                         │                     │   SQLite DB   │  │
-                         │                     │  fitman.db    │  │
+                         │                     │  PostgreSQL   │  │
+                         │                     │  Port 5432    │  │
                          │                     └───────────────┘  │
                          └─────────────────────────────────────────┘
 ```
@@ -27,7 +27,7 @@ Fitman is a two-service web application: a Python REST API and a React single-pa
 
 - Serves a REST JSON API consumed by the frontend
 - Handles authentication (JWT tokens)
-- Reads and writes all data to SQLite via SQLAlchemy
+- Reads and writes all data to PostgreSQL via SQLAlchemy
 - Runs database migrations automatically on startup via Alembic
 - Runs on port `8000` inside Docker (internal only — not exposed to the host)
 
@@ -115,8 +115,8 @@ users
   height_cm       REAL
   is_active       BOOLEAN NOT NULL DEFAULT 1
   is_admin        BOOLEAN NOT NULL DEFAULT 0
-  created_at      TEXT NOT NULL
-  consent_given_at TEXT                   -- ISO timestamp; NULL for users created before #138
+  created_at      TIMESTAMPTZ NOT NULL
+  consent_given_at TIMESTAMPTZ             -- NULL for users created before #138
 ```
 
 ### Strength training
@@ -134,8 +134,8 @@ exercises
 workout_sessions
   id          INTEGER PRIMARY KEY
   session     TEXT NOT NULL          -- "Push A" | "Pull A" | "Legs A"
-  started_at  TEXT NOT NULL
-  ended_at    TEXT                   -- null while in progress
+  started_at  TIMESTAMPTZ NOT NULL
+  ended_at    TIMESTAMPTZ             -- null while in progress
 
 logs
   id          INTEGER PRIMARY KEY
@@ -143,7 +143,7 @@ logs
   session_id  INTEGER REFERENCES workout_sessions(id)
   weight      REAL NOT NULL          -- kg (0 for bodyweight exercises)
   reps        INTEGER NOT NULL
-  logged_at   TEXT NOT NULL
+  logged_at   TIMESTAMPTZ NOT NULL
 ```
 
 ### Cardio
@@ -155,7 +155,7 @@ cardio_entries
   distance_m   REAL                   -- metres (null if not tracked)
   duration_s   INTEGER                -- seconds (null if not tracked)
   notes        TEXT
-  logged_at    TEXT NOT NULL
+  logged_at    TIMESTAMPTZ NOT NULL
 ```
 
 ### Body measurements
@@ -163,7 +163,7 @@ cardio_entries
 ```
 body_measurements
   id                  INTEGER PRIMARY KEY
-  recorded_at         TEXT NOT NULL
+  recorded_at         TIMESTAMPTZ NOT NULL
   weight_kg           REAL
   height_cm           REAL
   notes               TEXT

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -315,10 +315,9 @@ GDPR Article 32 requires "appropriate technical and organisational measures" to 
 
 | Option | Assessment |
 |---|---|
-| Filesystem / volume encryption | Recommended. Encrypts the entire SQLite file transparently. Zero app code changes. Protects against disk theft or backup exfiltration. |
-| SQLCipher (encrypted SQLite) | Requires rebuilding pysqlite against libsqlcipher. Fragile in Docker, significant build complexity for marginal gain over filesystem encryption. |
-| Column-level encryption (`cryptography` lib) | Most granular, but: requires managing an encryption key in `.env`, breaks `WHERE` queries on encrypted columns, complicates backups and exports. Disproportionate for this scope. |
-| PostgreSQL TDE / pgcrypto | Relevant if migrating to PostgreSQL (M19). Revisit then. |
+| Filesystem / volume encryption | Recommended. Encrypts the PostgreSQL data volume transparently. Zero app code changes. Protects against disk theft or backup exfiltration. |
+| pgcrypto / column-level encryption | Most granular, but: requires managing an encryption key in `.env`, breaks `WHERE` queries on encrypted columns, complicates backups and exports. Disproportionate for this scope. |
+| Column-level encryption (`cryptography` lib) | Same trade-offs as pgcrypto with more application complexity. Not recommended. |
 
 **Key management (filesystem approach):** Use Linux LUKS or macOS FileVault on the host machine, or encrypt the Docker volume via the host's block device. The `SECRET_KEY` in `.env` remains the only application-level secret and should not be committed to version control.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Commercial fitness apps either cost a recurring subscription or monetise your tr
 |---|---|
 | Backend API | Python 3.11 + FastAPI |
 | Frontend | React 18 + TypeScript + Tailwind CSS |
-| Database | SQLite (via SQLAlchemy) |
+| Database | PostgreSQL 16 (via SQLAlchemy) |
 | Auth | JWT |
 | Infra | Docker Compose + nginx + Tailscale |
 
@@ -102,6 +102,22 @@ docker compose -f docker-compose.prod.yml up -d --build
 docker compose -f docker-compose.prod.yml down
 ```
 
+### Migrating from SQLite (M18 → M19 upgrade)
+
+If you ran a previous version of Fitman backed by SQLite, your data is in a `fitman.db` file. PostgreSQL is not compatible with SQLite backups directly — you need to export and re-import your data.
+
+**Option A — Fresh start (recommended for personal use)**
+
+1. Note down any data you want to keep manually
+2. Deploy the new version: `docker compose -f docker-compose.prod.yml up -d --build`
+3. Visit `/setup` to create a new admin account
+
+**Option B — Data migration**
+
+1. Export your data via the old app: `GET /api/gdpr/export` (returns JSON)
+2. Bring up the new PostgreSQL-backed version
+3. Re-import your workout history via the API or manually
+
 ### Backups
 
 Run a backup manually at any time (safe while the app is live):
@@ -146,14 +162,19 @@ docker compose -f docker-compose.prod.yml up -d
 ## Development setup
 
 ```bash
+# Start PostgreSQL for local development (requires Docker)
+docker run -d --name fitman-postgres \
+  -e POSTGRES_DB=fitman -e POSTGRES_USER=fitman -e POSTGRES_PASSWORD=fitman \
+  -p 5432:5432 postgres:16
+
 # Backend — run from the backend/ directory
 cd backend
 uv venv .venv --python 3.11
 source .venv/bin/activate
 uv pip install -r requirements.txt -r requirements-dev.txt
 pre-commit install
-alembic upgrade head
-fastapi dev main.py
+DATABASE_URL=postgresql://fitman:fitman@localhost:5432/fitman alembic upgrade head
+DATABASE_URL=postgresql://fitman:fitman@localhost:5432/fitman fastapi dev main.py
 
 # Frontend — run from the frontend/ directory
 cd frontend

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ If you share this app with others on your Tailscale network, users should know:
 - **What is stored:** workout sessions, sets, cardio entries, body measurements (weight, body fat %, BIA impedance readings), and profile fields (display name, birth year, sex, height)
 - **Where it is stored:** exclusively on your self-hosted server — no data is sent to any third party
 - **User rights:** each user can export all their data (`GET /api/gdpr/export`) or permanently delete their account and all associated data (`DELETE /api/gdpr/erase`) at any time
-- **Encryption:** data is stored in a SQLite database file; protect it with filesystem-level encryption on the host (see [ARCHITECTURE.md](ARCHITECTURE.md) for the full decision)
+- **Encryption:** data is stored in a PostgreSQL database running on your server; protect it with filesystem-level encryption on the host (see [ARCHITECTURE.md](ARCHITECTURE.md) for the full decision)
 
 ## Branch strategy
 

--- a/README.md
+++ b/README.md
@@ -120,14 +120,11 @@ If you ran a previous version of Fitman backed by SQLite, your data is in a `fit
 
 ### Backups
 
-Run a backup manually at any time (safe while the app is live):
+Back up the database with `pg_dump` — safe to run while the app is live:
 
 ```bash
-chmod +x scripts/backup.sh
-./scripts/backup.sh
+docker exec fitman-postgres pg_dump -U fitman fitman > backups/fitman_$(date +%Y%m%d_%H%M%S).sql
 ```
-
-Backups are saved to `backups/fitman_YYYYMMDD_HHMMSS.db`. The script keeps the last 7 and deletes older ones automatically.
 
 **Set up a daily automatic backup with cron:**
 
@@ -138,20 +135,17 @@ crontab -e
 Add this line to run every day at 3am:
 
 ```
-0 3 * * * /path/to/Fitman/scripts/backup.sh >> /path/to/Fitman/backups/backup.log 2>&1
+0 3 * * * docker exec fitman-postgres pg_dump -U fitman fitman > /path/to/Fitman/backups/fitman_$(date +\%Y\%m\%d_\%H\%M\%S).sql
 ```
 
 **Restoring from a backup:**
 
 ```bash
-# 1. Stop the app
-docker compose -f docker-compose.prod.yml down
+# 1. Stop the backend (keep postgres running)
+docker compose -f docker-compose.prod.yml stop backend frontend
 
-# 2. Copy the backup into the Docker volume
-docker run --rm \
-  -v fitman_db_data:/data \
-  -v $(pwd)/backups:/backups \
-  alpine cp /backups/fitman_YYYYMMDD_HHMMSS.db /data/fitman.db
+# 2. Restore the dump
+docker exec -i fitman-postgres psql -U fitman fitman < backups/fitman_YYYYMMDD_HHMMSS.sql
 
 # 3. Start the app again
 docker compose -f docker-compose.prod.yml up -d

--- a/TESTING.md
+++ b/TESTING.md
@@ -12,9 +12,19 @@ The test is reviewed and agreed before any implementation code is written. This 
 
 ## Running the tests
 
+Tests run against a real PostgreSQL database. Start one first if you don't have it running:
+
+```bash
+docker run -d --name fitman-postgres \
+  -e POSTGRES_DB=fitman_test -e POSTGRES_USER=fitman -e POSTGRES_PASSWORD=fitman \
+  -p 5432:5432 postgres:16
+```
+
+Then run the suite:
+
 ```bash
 cd backend
-.venv/bin/pytest
+DATABASE_URL=postgresql://fitman:fitman@localhost:5432/fitman_test .venv/bin/pytest
 ```
 
 Run with verbose output:
@@ -52,6 +62,8 @@ All tests live in `backend/tests/`. The suite uses a single in-memory SQLite dat
 | `test_sessions.py` | Full workout session flow: start → log sets → end → list → get logs; edge cases (unknown session, already ended, 404); N+1 query regression guard (asserts ≤2 SELECT statements on list endpoint) |
 | `test_stats.py` | Home stats structure, streak calculation (unit + UTC correctness), week bounds (UTC correctness) |
 
+| `test_postgresql.py` | PostgreSQL migration structural tests: engine dialect is postgresql, no TZDateTime custom type in any model |
+
 ## conftest.py
 
 A single `session`-scoped `TestClient` is shared across all tests. The database is created fresh at the start of the test run (`Base.metadata.drop_all` + `create_all`) and seeded with:
@@ -60,6 +72,8 @@ A single `session`-scoped `TestClient` is shared across all tests. The database 
 - The full exercise library (via `seed.py`)
 
 Because the database is shared across tests, individual tests must not rely on the database being empty. Tests that need specific data insert it directly via `SessionLocal`.
+
+`DATABASE_URL` must be set in the environment before the test session starts. `conftest.py` defaults to `postgresql://fitman:fitman@localhost:5432/fitman_test` if the variable is not set.
 
 ## Pre-commit hooks
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -41,7 +41,7 @@ Run a single file:
 
 ## Test structure
 
-All tests live in `backend/tests/`. The suite uses a single in-memory SQLite database (see `conftest.py`) seeded with one test user and the full exercise library.
+All tests live in `backend/tests/`. The suite runs against a real PostgreSQL database (see `conftest.py`) seeded with one test user and the full exercise library.
 
 | File | What it covers |
 |---|---|
@@ -49,7 +49,7 @@ All tests live in `backend/tests/`. The suite uses a single in-memory SQLite dat
 | `test_admin.py` | Admin user management: list users, create, disable/enable, delete (with data cascade); 403 for non-admins, self-disable/delete blocked |
 | `test_auth.py` | Password hashing, login, registration validation (min length, consent required), JWT-protected endpoints, password change (wrong current → 400, short new → 422, success) |
 | `test_cardio.py` | Cardio entry logging, list, delete, activity validation, schema contract (no `session_id`) |
-| `test_database_pool.py` | Connection pool configuration: verifies DB_POOL_SIZE, DB_MAX_OVERFLOW, DB_POOL_TIMEOUT env vars are read and applied; default values; uses a temp file-based SQLite URL (not :memory:) to exercise QueuePool |
+| `test_database_pool.py` | Connection pool configuration: verifies DB_POOL_SIZE, DB_MAX_OVERFLOW, DB_POOL_TIMEOUT env vars are read and applied; default values; uses `DATABASE_URL` from the environment (PostgreSQL) |
 | `test_entrypoint.py` | entrypoint.sh behaviour: non-zero exit and clear error message to stderr when migration fails; uvicorn not invoked on failure, invoked on success |
 | `test_exercises.py` | Exercise list (session + search filters), exercise by ID, sessions list |
 | `test_gdpr.py` | Right to erasure (401, 204, cascade delete); data export (401, structure, no password hash, Content-Disposition header, workout sessions included) |

--- a/backend/alembic/versions/f1a2b3c4d5e6_convert_datetime_columns_to_timestamptz.py
+++ b/backend/alembic/versions/f1a2b3c4d5e6_convert_datetime_columns_to_timestamptz.py
@@ -1,0 +1,55 @@
+"""convert datetime columns to timestamptz
+
+Revision ID: f1a2b3c4d5e6
+Revises: e2f9a3b7c1d5
+Create Date: 2026-07-05
+
+Historical migrations created datetime columns as VARCHAR (TZDateTime's
+SQLite impl).  This migration converts them to TIMESTAMPTZ on PostgreSQL.
+ISO 8601 strings stored by the old SQLite backend cast cleanly to TIMESTAMPTZ.
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f1a2b3c4d5e6"
+down_revision: Union[str, Sequence[str], None] = "e2f9a3b7c1d5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# (table, column, nullable)
+_DATETIME_COLUMNS = [
+    ("workout_sessions", "started_at", False),
+    ("workout_sessions", "ended_at", True),
+    ("logs", "logged_at", False),
+    ("cardio_entries", "logged_at", False),
+    ("body_measurements", "recorded_at", False),
+    ("users", "created_at", False),
+    ("users", "consent_given_at", True),
+]
+
+
+def upgrade() -> None:
+    for table, column, nullable in _DATETIME_COLUMNS:
+        op.alter_column(
+            table,
+            column,
+            type_=sa.DateTime(timezone=True),
+            existing_type=sa.String(),
+            existing_nullable=nullable,
+            postgresql_using=f"{column}::timestamptz",
+        )
+
+
+def downgrade() -> None:
+    for table, column, nullable in reversed(_DATETIME_COLUMNS):
+        op.alter_column(
+            table,
+            column,
+            type_=sa.String(),
+            existing_type=sa.DateTime(timezone=True),
+            existing_nullable=nullable,
+        )

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,23 +1,17 @@
 import os
-from datetime import datetime, timezone
 
 from dotenv import find_dotenv, load_dotenv
-from sqlalchemy import String, create_engine
+from sqlalchemy import create_engine
 from sqlalchemy.orm import DeclarativeBase, sessionmaker
-from sqlalchemy.types import TypeDecorator
 
 load_dotenv(find_dotenv())
 
-DATA_DIR = os.getenv("DATA_DIR", "./data")
-os.makedirs(DATA_DIR, exist_ok=True)
-
-DATABASE_URL = f"sqlite:///{DATA_DIR}/fitman.db"
+DATABASE_URL = os.environ["DATABASE_URL"]
 
 
 def _make_engine(url: str):
     return create_engine(
         url,
-        connect_args={"check_same_thread": False},
         pool_size=int(os.getenv("DB_POOL_SIZE", "5")),
         max_overflow=int(os.getenv("DB_MAX_OVERFLOW", "10")),
         pool_timeout=int(os.getenv("DB_POOL_TIMEOUT", "30")),
@@ -27,28 +21,6 @@ def _make_engine(url: str):
 engine = _make_engine(DATABASE_URL)
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-
-
-class TZDateTime(TypeDecorator):
-    """Stores datetimes as ISO strings, returns timezone-aware UTC datetime objects."""
-
-    impl = String
-    cache_ok = True
-
-    def process_bind_param(self, value: datetime | None, dialect) -> str | None:
-        if value is None:
-            return None
-        if value.tzinfo is None:
-            value = value.replace(tzinfo=timezone.utc)
-        return value.isoformat()
-
-    def process_result_value(self, value: str | None, dialect) -> datetime | None:
-        if value is None:
-            return None
-        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        return dt
 
 
 class Base(DeclarativeBase):

--- a/backend/models/cardio.py
+++ b/backend/models/cardio.py
@@ -1,9 +1,9 @@
 from datetime import datetime
 
-from sqlalchemy import Float, ForeignKey, Integer, String
+from sqlalchemy import DateTime, Float, ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
-from database import Base, TZDateTime
+from database import Base
 
 
 class CardioEntry(Base):
@@ -17,4 +17,4 @@ class CardioEntry(Base):
     distance_m: Mapped[float | None] = mapped_column(Float)
     duration_s: Mapped[int | None] = mapped_column(Integer)
     notes: Mapped[str | None] = mapped_column(String)
-    logged_at: Mapped[datetime] = mapped_column(TZDateTime, nullable=False)
+    logged_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/backend/models/measurement.py
+++ b/backend/models/measurement.py
@@ -1,9 +1,9 @@
 from datetime import datetime
 
-from sqlalchemy import Float, ForeignKey, Integer, String
+from sqlalchemy import DateTime, Float, ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
-from database import Base, TZDateTime
+from database import Base
 
 
 class BodyMeasurement(Base):
@@ -13,7 +13,9 @@ class BodyMeasurement(Base):
     user_id: Mapped[int] = mapped_column(
         Integer, ForeignKey("users.id"), nullable=False, index=True
     )
-    recorded_at: Mapped[datetime] = mapped_column(TZDateTime, nullable=False)
+    recorded_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
 
     # ── Basic ──────────────────────────────────────────────────────────────────
     weight_kg: Mapped[float | None] = mapped_column(Float)

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -1,9 +1,9 @@
 from datetime import datetime
 
-from sqlalchemy import Boolean, Float, Integer, String
+from sqlalchemy import Boolean, DateTime, Float, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
-from database import Base, TZDateTime
+from database import Base
 
 
 class User(Base):
@@ -19,5 +19,7 @@ class User(Base):
     height_cm: Mapped[float | None] = mapped_column(Float)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     is_admin: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
-    created_at: Mapped[datetime] = mapped_column(TZDateTime, nullable=False)
-    consent_given_at: Mapped[datetime | None] = mapped_column(TZDateTime)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    consent_given_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))

--- a/backend/models/workout.py
+++ b/backend/models/workout.py
@@ -1,9 +1,9 @@
 from datetime import datetime
 
-from sqlalchemy import Float, ForeignKey, Integer, String
+from sqlalchemy import DateTime, Float, ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from database import Base, TZDateTime
+from database import Base
 
 
 class WorkoutSession(Base):
@@ -14,8 +14,10 @@ class WorkoutSession(Base):
         Integer, ForeignKey("users.id"), nullable=False, index=True
     )
     session: Mapped[str] = mapped_column(String, nullable=False)
-    started_at: Mapped[datetime] = mapped_column(TZDateTime, nullable=False)
-    ended_at: Mapped[datetime | None] = mapped_column(TZDateTime)
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    ended_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
     logs: Mapped[list["Log"]] = relationship("Log", back_populates="workout_session")
 
@@ -32,7 +34,7 @@ class Log(Base):
     )
     weight: Mapped[float] = mapped_column(Float, nullable=False)
     reps: Mapped[int] = mapped_column(Integer, nullable=False)
-    logged_at: Mapped[datetime] = mapped_column(TZDateTime, nullable=False)
+    logged_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
 
     workout_session: Mapped["WorkoutSession"] = relationship(
         "WorkoutSession", back_populates="logs"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,4 @@ pydantic==2.13.4
 PyJWT==2.13.0
 bcrypt==5.0.0
 python-dotenv==1.2.2
+psycopg2-binary==2.9.10

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -5,11 +5,12 @@ import bcrypt
 import pytest
 from fastapi.testclient import TestClient
 
-# Must be set before the app is imported so main.py startup checks pass
 os.environ.setdefault(
     "SECRET_KEY", "test-secret-key-for-ci-only-not-for-production-use"
 )
-os.environ.setdefault("DATA_DIR", "/tmp/fitman_test")
+os.environ.setdefault(
+    "DATABASE_URL", "postgresql://fitman:fitman@localhost:5432/fitman_test"
+)
 
 from database import Base, SessionLocal, engine  # noqa: E402
 from main import app  # noqa: E402

--- a/backend/tests/test_database_pool.py
+++ b/backend/tests/test_database_pool.py
@@ -1,84 +1,84 @@
 """Connection pool configuration tests (#134).
 
-Tests call _make_engine() directly with a temp file-based SQLite URL
-(not :memory:, which uses StaticPool and doesn't accept pool_size args)
-and monkeypatched env vars so the module-level singleton engine is never
-touched.
+Tests call _make_engine() directly with monkeypatched env vars so the
+module-level singleton engine is never touched.  Uses DATABASE_URL from
+the environment (PostgreSQL) — pool_size args don't apply to SQLite's
+StaticPool so a real PostgreSQL URL is required.
 """
 
-from pathlib import Path
+import os
 
 
-def _url(tmp_path: Path) -> str:
-    return f"sqlite:///{tmp_path}/test.db"
+def _url() -> str:
+    return os.environ["DATABASE_URL"]
 
 
-def test_pool_size_defaults_to_five(monkeypatch, tmp_path):
+def test_pool_size_defaults_to_five(monkeypatch):
     """Without DB_POOL_SIZE the pool must default to 5."""
     monkeypatch.delenv("DB_POOL_SIZE", raising=False)
     from database import _make_engine
 
-    e = _make_engine(_url(tmp_path))
+    e = _make_engine(_url())
     try:
         assert e.pool.size() == 5
     finally:
         e.dispose()
 
 
-def test_pool_size_is_configurable(monkeypatch, tmp_path):
+def test_pool_size_is_configurable(monkeypatch):
     """DB_POOL_SIZE env var must set the pool size."""
     monkeypatch.setenv("DB_POOL_SIZE", "3")
     from database import _make_engine
 
-    e = _make_engine(_url(tmp_path))
+    e = _make_engine(_url())
     try:
         assert e.pool.size() == 3
     finally:
         e.dispose()
 
 
-def test_max_overflow_defaults_to_ten(monkeypatch, tmp_path):
+def test_max_overflow_defaults_to_ten(monkeypatch):
     """Without DB_MAX_OVERFLOW the pool must default to 10."""
     monkeypatch.delenv("DB_MAX_OVERFLOW", raising=False)
     from database import _make_engine
 
-    e = _make_engine(_url(tmp_path))
+    e = _make_engine(_url())
     try:
         assert e.pool._max_overflow == 10
     finally:
         e.dispose()
 
 
-def test_max_overflow_is_configurable(monkeypatch, tmp_path):
+def test_max_overflow_is_configurable(monkeypatch):
     """DB_MAX_OVERFLOW env var must set the pool max overflow."""
     monkeypatch.setenv("DB_MAX_OVERFLOW", "2")
     from database import _make_engine
 
-    e = _make_engine(_url(tmp_path))
+    e = _make_engine(_url())
     try:
         assert e.pool._max_overflow == 2
     finally:
         e.dispose()
 
 
-def test_pool_timeout_defaults_to_thirty(monkeypatch, tmp_path):
+def test_pool_timeout_defaults_to_thirty(monkeypatch):
     """Without DB_POOL_TIMEOUT the pool timeout must default to 30 seconds."""
     monkeypatch.delenv("DB_POOL_TIMEOUT", raising=False)
     from database import _make_engine
 
-    e = _make_engine(_url(tmp_path))
+    e = _make_engine(_url())
     try:
         assert e.pool._timeout == 30
     finally:
         e.dispose()
 
 
-def test_pool_timeout_is_configurable(monkeypatch, tmp_path):
+def test_pool_timeout_is_configurable(monkeypatch):
     """DB_POOL_TIMEOUT env var must set the pool timeout in seconds."""
     monkeypatch.setenv("DB_POOL_TIMEOUT", "15")
     from database import _make_engine
 
-    e = _make_engine(_url(tmp_path))
+    e = _make_engine(_url())
     try:
         assert e.pool._timeout == 15
     finally:

--- a/backend/tests/test_postgresql.py
+++ b/backend/tests/test_postgresql.py
@@ -1,0 +1,62 @@
+"""PostgreSQL migration structural tests (#132).
+
+These tests verify the engine and models are PostgreSQL-native — no SQLite
+custom types, no SQLite-specific connection arguments.
+"""
+
+from database import engine
+
+
+def test_engine_dialect_is_postgresql():
+    """The engine must connect to PostgreSQL, not SQLite."""
+    assert engine.dialect.name == "postgresql", (
+        f"Expected postgresql dialect, got {engine.dialect.name!r}. "
+        "Set DATABASE_URL=postgresql://fitman:fitman@localhost:5432/fitman_test"
+    )
+
+
+def test_no_tztime_custom_type_in_user_model():
+    """User model must use DateTime(timezone=True), not the custom TZDateTime."""
+    from sqlalchemy import DateTime
+
+    from models.user import User
+
+    for col in User.__table__.columns:
+        assert not col.type.__class__.__name__ == "TZDateTime", (
+            f"Column {col.name!r} still uses TZDateTime — replace with DateTime(timezone=True)"
+        )
+        if hasattr(col.type, "timezone"):
+            assert col.type.timezone is True or not isinstance(col.type, DateTime), (
+                f"DateTime column {col.name!r} must have timezone=True"
+            )
+
+
+def test_no_tztime_custom_type_in_workout_models():
+    """WorkoutSession and Log must use DateTime(timezone=True), not TZDateTime."""
+    from models.workout import Log, WorkoutSession
+
+    for model in (WorkoutSession, Log):
+        for col in model.__table__.columns:
+            assert col.type.__class__.__name__ != "TZDateTime", (
+                f"{model.__name__}.{col.name} still uses TZDateTime"
+            )
+
+
+def test_no_tztime_custom_type_in_cardio_model():
+    """CardioEntry must use DateTime(timezone=True), not TZDateTime."""
+    from models.cardio import CardioEntry
+
+    for col in CardioEntry.__table__.columns:
+        assert col.type.__class__.__name__ != "TZDateTime", (
+            f"CardioEntry.{col.name} still uses TZDateTime"
+        )
+
+
+def test_no_tztime_custom_type_in_measurement_model():
+    """BodyMeasurement must use DateTime(timezone=True), not TZDateTime."""
+    from models.measurement import BodyMeasurement
+
+    for col in BodyMeasurement.__table__.columns:
+        assert col.type.__class__.__name__ != "TZDateTime", (
+            f"BodyMeasurement.{col.name} still uses TZDateTime"
+        )

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,10 +1,26 @@
 services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: fitman
+      POSTGRES_USER: fitman
+      POSTGRES_PASSWORD: fitman
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U fitman"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
   backend:
     build: ./backend
-    volumes:
-      - db_data:/app/data
     env_file:
       - .env
+    depends_on:
+      postgres:
+        condition: service_healthy
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,28 @@
 services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: fitman
+      POSTGRES_USER: fitman
+      POSTGRES_PASSWORD: fitman
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U fitman"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
   backend:
     build: ./backend
     ports:
       - "8000:8000"
-    volumes:
-      - db_data:/app/data
     env_file:
       - .env
+    depends_on:
+      postgres:
+        condition: service_healthy
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]


### PR DESCRIPTION
## M19 — PostgreSQL Migration

Replaces SQLite with PostgreSQL across the full stack.

### What changed

**#133 — Graceful migration failure handling in entrypoint.sh** (landed in M18)
Already merged. entrypoint.sh now emits a clear ERROR message to stderr and
exits 1 if alembic fails, rather than silently dying via set -e.

**#134 — SQLAlchemy connection pool configuration** (landed in M18)
Already merged. DB_POOL_SIZE, DB_MAX_OVERFLOW, DB_POOL_TIMEOUT are now
configurable via env vars with sensible defaults.

**#132 — Migrate database from SQLite to PostgreSQL**
- psycopg2-binary added to requirements
- Removed custom TZDateTime type — all datetime columns now use
  DateTime(timezone=True), mapping to native TIMESTAMPTZ in PostgreSQL
- database.py reads DATABASE_URL from env; DATA_DIR and check_same_thread
  removed
- New Alembic migration converts historical VARCHAR datetime columns to
  TIMESTAMPTZ via ISO 8601 cast (works on fresh and existing databases)
- postgres:16 service added to both docker-compose files with healthcheck;
  backend depends_on postgres being healthy before starting
- CI updated: services block removed (self-hosted runner uses the always-on
  local postgres); DATABASE_URL replaces DATA_DIR in test env
- conftest.py defaults to postgresql://fitman:fitman@localhost:5432/fitman_test
- README: updated tech stack, dev setup, backups (pg_dump), SQLite→PostgreSQL
  migration guide
- ARCHITECTURE.md, TESTING.md, .env.example updated throughout

Closes #132 

### Test suite
166 passing against PostgreSQL. All Alembic migrations run clean on a fresh
PostgreSQL instance. ruff + mypy clean.

### No breaking changes to the API
All endpoint contracts unchanged. The database engine is an internal
implementation detail — clients see no difference.
