### PR TITLE
fix: add explicit consent checkbox to first-run setup screen

### DIFF
--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -10,10 +10,10 @@ export async function checkSetupRequired(): Promise<boolean> {
   return data.required
 }
 
-export async function register(username: string, password: string, displayName?: string): Promise<void> {
+export async function register(username: string, password: string, displayName?: string, consentGiven = false): Promise<void> {
   const data = await request<TokenResponse>('/api/auth/register', {
     method: 'POST',
-    body: JSON.stringify({ username, password, display_name: displayName || undefined }),
+    body: JSON.stringify({ username, password, display_name: displayName || undefined, consent_given: consentGiven }),
   })
   saveToken(data.access_token)
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -22,7 +22,10 @@ export async function request<T>(path: string, options: RequestInit = {}): Promi
 
   if (!res.ok) {
     const error = await res.json().catch(() => ({ detail: 'Request failed' }))
-    throw new Error(error.detail ?? 'Request failed')
+    const detail = Array.isArray(error.detail)
+      ? error.detail.map((e: { msg: string }) => e.msg).join(', ')
+      : (error.detail ?? 'Request failed')
+    throw new Error(detail)
   }
 
   if (res.status === 204) return undefined as T

--- a/frontend/src/pages/SetupPage.tsx
+++ b/frontend/src/pages/SetupPage.tsx
@@ -6,6 +6,7 @@ export default function SetupPage() {
   const [displayName, setDisplayName] = useState('')
   const [password, setPassword]       = useState('')
   const [confirm, setConfirm]         = useState('')
+  const [consentGiven, setConsentGiven] = useState(false)
   const [error, setError]             = useState('')
   const [loading, setLoading]         = useState(false)
 
@@ -24,7 +25,7 @@ export default function SetupPage() {
 
     setLoading(true)
     try {
-      await register(username, password, displayName)
+      await register(username, password, displayName, consentGiven)
       // Full reload so App re-checks setup-required and enters normal routing
       window.location.href = '/'
     } catch (err) {
@@ -102,11 +103,23 @@ export default function SetupPage() {
             />
           </div>
 
+          <label className="flex items-start gap-3 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={consentGiven}
+              onChange={e => setConsentGiven(e.target.checked)}
+              className="mt-0.5 accent-[var(--color-accent)]"
+            />
+            <span className="text-sm text-[var(--color-muted)]">
+              I understand my workout data, body measurements, and profile are stored on this server. No data is sent to any third party.
+            </span>
+          </label>
+
           {error && <p className="text-sm text-red-500">{error}</p>}
 
           <button
             type="submit"
-            disabled={loading}
+            disabled={loading || !consentGiven}
             className="w-full py-2 px-4 bg-[var(--color-accent)] text-white font-semibold rounded-lg disabled:opacity-50"
           >
             {loading ? 'Creating account…' : 'Create account'}


### PR DESCRIPTION
User must tick a consent acknowledgement before the Create Account button is enabled. Consent flag is now passed from UI state rather than hardcoded. Also fixes 422 error display in client.ts (FastAPI validation errors return detail as an array, not a string).

Closes #155