### PR TITLE
feat: settings page with profile, password change, and GDPR controls

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import WorkoutDetailPage from './pages/WorkoutDetailPage'
 import ProgressPage from './pages/ProgressPage'
 import LibraryPage from './pages/LibraryPage'
 import CardioPage from './pages/CardioPage'
+import SettingsPage from './pages/SettingsPage'
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   if (!Boolean(getToken())) return <Navigate to="/login" replace />
@@ -53,6 +54,7 @@ export default function App() {
         <Route path="/progress" element={<ProtectedRoute><ProgressPage /></ProtectedRoute>} />
         <Route path="/library" element={<ProtectedRoute><LibraryPage /></ProtectedRoute>} />
         <Route path="/cardio" element={<ProtectedRoute><CardioPage /></ProtectedRoute>} />
+        <Route path="/settings" element={<ProtectedRoute><SettingsPage /></ProtectedRoute>} />
         <Route path="*" element={<Navigate to={Boolean(getToken()) ? '/' : '/login'} replace />} />
       </Routes>
     </BrowserRouter>

--- a/frontend/src/api/gdpr.ts
+++ b/frontend/src/api/gdpr.ts
@@ -1,0 +1,22 @@
+import { request, getToken } from './client'
+
+export async function exportData(): Promise<void> {
+  const token = getToken()
+  const res = await fetch('/api/gdpr/export', {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  })
+  if (!res.ok) throw new Error('Export failed')
+  const blob = await res.blob()
+  const disposition = res.headers.get('Content-Disposition') ?? ''
+  const filename = disposition.match(/filename="(.+)"/)?.[1] ?? 'fitman-data.json'
+  const a = document.createElement('a')
+  a.href = URL.createObjectURL(blob)
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+}
+
+export function eraseAccount(): Promise<void> {
+  return request<void>('/api/gdpr/erase', { method: 'DELETE' })
+}

--- a/frontend/src/api/profile.ts
+++ b/frontend/src/api/profile.ts
@@ -1,0 +1,34 @@
+import { request } from './client'
+
+export interface Profile {
+  username: string
+  email: string | null
+  display_name: string | null
+  birth_year: number | null
+  sex: string | null
+  height_cm: number | null
+  is_admin: boolean
+}
+
+export function getProfile(): Promise<Profile> {
+  return request<Profile>('/api/profile')
+}
+
+export function updateProfile(data: {
+  display_name?: string | null
+  birth_year?: number | null
+  sex?: 'male' | 'female' | 'other' | null
+  height_cm?: number | null
+}): Promise<Profile> {
+  return request<Profile>('/api/profile', {
+    method: 'PATCH',
+    body: JSON.stringify(data),
+  })
+}
+
+export function changePassword(currentPassword: string, newPassword: string): Promise<void> {
+  return request<void>('/api/auth/change-password', {
+    method: 'POST',
+    body: JSON.stringify({ current_password: currentPassword, new_password: newPassword }),
+  })
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,3 +1,5 @@
+import { NavLink } from 'react-router-dom'
+import { Settings } from 'lucide-react'
 import Sidebar from './Sidebar'
 import BottomNav from './BottomNav'
 
@@ -6,6 +8,12 @@ export default function Layout({ children }: { children: React.ReactNode }) {
     <div className="flex h-full">
       <Sidebar />
       <div className="flex flex-col flex-1 min-w-0 min-h-0">
+        {/* Mobile-only settings access */}
+        <div className="md:hidden flex justify-end px-4 py-3 border-b border-[var(--color-border)] bg-[var(--color-surface)]">
+          <NavLink to="/settings" className={({ isActive }) => isActive ? 'text-[var(--color-accent)]' : 'text-[var(--color-muted)]'}>
+            <Settings size={20} />
+          </NavLink>
+        </div>
         <div className="flex-1 overflow-y-auto">
           {children}
         </div>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -59,10 +59,19 @@ export default function Sidebar() {
           {active ? <Play size={18} strokeWidth={2.2} fill="#fff" /> : <Plus size={18} strokeWidth={2.2} />}
           {active ? `Resume ${active.session}` : 'Start workout'}
         </button>
-        <button className="flex items-center gap-3 px-3 py-[10px] rounded-xl text-[var(--color-muted)] font-semibold text-[14.5px] hover:bg-[var(--color-bg)] hover:text-[var(--color-text)] transition-colors">
+        <NavLink
+          to="/settings"
+          className={({ isActive }) =>
+            `flex items-center gap-3 px-3 py-[10px] rounded-xl font-semibold text-[14.5px] transition-colors ${
+              isActive
+                ? 'bg-[var(--color-accent-soft)] text-[var(--color-accent)]'
+                : 'text-[var(--color-muted)] hover:bg-[var(--color-bg)] hover:text-[var(--color-text)]'
+            }`
+          }
+        >
           <Settings size={20} />
           Settings
-        </button>
+        </NavLink>
       </div>
     </aside>
   )

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,0 +1,301 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { ArrowLeft, Download, Trash2, AlertTriangle } from 'lucide-react'
+import { getProfile, updateProfile, changePassword, type Profile } from '../api/profile'
+import { exportData, eraseAccount } from '../api/gdpr'
+import { logout } from '../api/auth'
+
+const inputCls = 'w-full px-3 py-2 rounded-xl border border-[var(--color-border)] bg-[var(--color-bg)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]'
+const labelCls = 'text-xs text-[var(--color-muted)] mb-1.5 block'
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="bg-[var(--color-surface)] rounded-2xl border border-[var(--color-border)] p-4 space-y-4">
+      <h2 className="text-base font-semibold text-[var(--color-text)]">{title}</h2>
+      {children}
+    </section>
+  )
+}
+
+function Feedback({ msg }: { msg: { type: 'ok' | 'err'; text: string } | null }) {
+  if (!msg) return null
+  return (
+    <p className={`text-sm ${msg.type === 'ok' ? 'text-green-600' : 'text-red-500'}`}>
+      {msg.text}
+    </p>
+  )
+}
+
+export default function SettingsPage() {
+  const navigate = useNavigate()
+
+  // Profile
+  const [profile, setProfile] = useState<Profile | null>(null)
+  const [displayName, setDisplayName] = useState('')
+  const [birthYear, setBirthYear] = useState('')
+  const [sex, setSex] = useState('')
+  const [heightCm, setHeightCm] = useState('')
+  const [profileSaving, setProfileSaving] = useState(false)
+  const [profileMsg, setProfileMsg] = useState<{ type: 'ok' | 'err'; text: string } | null>(null)
+
+  // Password
+  const [currentPw, setCurrentPw] = useState('')
+  const [newPw, setNewPw] = useState('')
+  const [confirmPw, setConfirmPw] = useState('')
+  const [pwSaving, setPwSaving] = useState(false)
+  const [pwMsg, setPwMsg] = useState<{ type: 'ok' | 'err'; text: string } | null>(null)
+
+  // GDPR
+  const [exporting, setExporting] = useState(false)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const [gdprErr, setGdprErr] = useState<string | null>(null)
+
+  useEffect(() => {
+    getProfile()
+      .then(p => {
+        setProfile(p)
+        setDisplayName(p.display_name ?? '')
+        setBirthYear(p.birth_year?.toString() ?? '')
+        setSex(p.sex ?? '')
+        setHeightCm(p.height_cm?.toString() ?? '')
+      })
+      .catch(() => {})
+  }, [])
+
+  async function handleProfileSave() {
+    setProfileSaving(true)
+    setProfileMsg(null)
+    try {
+      const updated = await updateProfile({
+        display_name: displayName || null,
+        birth_year: birthYear ? parseInt(birthYear, 10) : null,
+        sex: (sex as 'male' | 'female' | 'other') || null,
+        height_cm: heightCm ? parseFloat(heightCm) : null,
+      })
+      setProfile(updated)
+      setProfileMsg({ type: 'ok', text: 'Profile saved.' })
+    } catch (err) {
+      setProfileMsg({ type: 'err', text: err instanceof Error ? err.message : 'Save failed.' })
+    } finally {
+      setProfileSaving(false)
+    }
+  }
+
+  async function handlePasswordChange() {
+    setPwMsg(null)
+    if (newPw.length < 8) {
+      setPwMsg({ type: 'err', text: 'New password must be at least 8 characters.' })
+      return
+    }
+    if (newPw !== confirmPw) {
+      setPwMsg({ type: 'err', text: 'Passwords do not match.' })
+      return
+    }
+    setPwSaving(true)
+    try {
+      await changePassword(currentPw, newPw)
+      setCurrentPw('')
+      setNewPw('')
+      setConfirmPw('')
+      setPwMsg({ type: 'ok', text: 'Password changed.' })
+    } catch (err) {
+      setPwMsg({ type: 'err', text: err instanceof Error ? err.message : 'Change failed.' })
+    } finally {
+      setPwSaving(false)
+    }
+  }
+
+  async function handleExport() {
+    setExporting(true)
+    setGdprErr(null)
+    try {
+      await exportData()
+    } catch {
+      setGdprErr('Export failed. Please try again.')
+    } finally {
+      setExporting(false)
+    }
+  }
+
+  async function handleErase() {
+    setDeleting(true)
+    try {
+      await eraseAccount()
+      logout()
+      window.location.href = '/'
+    } catch {
+      setGdprErr('Deletion failed. Please try again.')
+      setDeleting(false)
+      setConfirmDelete(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen pb-8">
+      <header className="px-4 pt-12 pb-6 flex items-center gap-3">
+        <button onClick={() => navigate(-1)} className="text-[var(--color-muted)] md:hidden">
+          <ArrowLeft size={20} />
+        </button>
+        <h1 className="text-2xl font-bold tracking-tight">Settings</h1>
+        {profile?.is_admin && (
+          <span className="ml-1 px-2 py-0.5 rounded-full bg-[var(--color-accent-soft)] text-[var(--color-accent)] text-xs font-semibold">
+            Admin
+          </span>
+        )}
+      </header>
+
+      <main className="px-4 space-y-6">
+
+        {/* Profile */}
+        <Section title="Profile">
+          <div>
+            <label className={labelCls}>Display name</label>
+            <input
+              type="text"
+              value={displayName}
+              onChange={e => setDisplayName(e.target.value)}
+              placeholder="e.g. Dave"
+              className={inputCls}
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className={labelCls}>Birth year</label>
+              <input
+                type="text"
+                inputMode="numeric"
+                value={birthYear}
+                onChange={e => setBirthYear(e.target.value)}
+                placeholder="1990"
+                className={inputCls}
+              />
+            </div>
+            <div>
+              <label className={labelCls}>Height (cm)</label>
+              <input
+                type="text"
+                inputMode="decimal"
+                value={heightCm}
+                onChange={e => setHeightCm(e.target.value)}
+                placeholder="180"
+                className={inputCls}
+              />
+            </div>
+          </div>
+          <div>
+            <label className={labelCls}>Sex</label>
+            <select value={sex} onChange={e => setSex(e.target.value)} className={inputCls}>
+              <option value="">Not set</option>
+              <option value="male">Male</option>
+              <option value="female">Female</option>
+              <option value="other">Other</option>
+            </select>
+          </div>
+          <Feedback msg={profileMsg} />
+          <button
+            onClick={handleProfileSave}
+            disabled={profileSaving}
+            className="w-full py-3 bg-[var(--color-accent)] text-white font-semibold rounded-xl disabled:opacity-40"
+          >
+            {profileSaving ? 'Saving…' : 'Save profile'}
+          </button>
+        </Section>
+
+        {/* Password */}
+        <Section title="Change password">
+          <div>
+            <label className={labelCls}>Current password</label>
+            <input
+              type="password"
+              value={currentPw}
+              onChange={e => setCurrentPw(e.target.value)}
+              autoComplete="current-password"
+              className={inputCls}
+            />
+          </div>
+          <div>
+            <label className={labelCls}>New password</label>
+            <input
+              type="password"
+              value={newPw}
+              onChange={e => setNewPw(e.target.value)}
+              autoComplete="new-password"
+              className={inputCls}
+            />
+          </div>
+          <div>
+            <label className={labelCls}>Confirm new password</label>
+            <input
+              type="password"
+              value={confirmPw}
+              onChange={e => setConfirmPw(e.target.value)}
+              autoComplete="new-password"
+              className={inputCls}
+            />
+          </div>
+          <Feedback msg={pwMsg} />
+          <button
+            onClick={handlePasswordChange}
+            disabled={pwSaving || !currentPw || !newPw || !confirmPw}
+            className="w-full py-3 bg-[var(--color-accent)] text-white font-semibold rounded-xl disabled:opacity-40"
+          >
+            {pwSaving ? 'Changing…' : 'Change password'}
+          </button>
+        </Section>
+
+        {/* Data & Privacy */}
+        <Section title="Data & privacy">
+          <p className="text-sm text-[var(--color-muted)]">
+            Your data is stored exclusively on this server. You can export a full copy or permanently delete your account at any time.
+          </p>
+          <button
+            onClick={handleExport}
+            disabled={exporting}
+            className="w-full flex items-center justify-center gap-2 py-3 border border-[var(--color-border)] rounded-xl text-sm font-semibold text-[var(--color-text)] hover:bg-[var(--color-bg)] transition-colors disabled:opacity-40"
+          >
+            <Download size={16} />
+            {exporting ? 'Preparing export…' : 'Download my data'}
+          </button>
+
+          {!confirmDelete ? (
+            <button
+              onClick={() => setConfirmDelete(true)}
+              className="w-full flex items-center justify-center gap-2 py-3 border border-red-200 rounded-xl text-sm font-semibold text-red-500 hover:bg-red-50 transition-colors"
+            >
+              <Trash2 size={16} />
+              Delete my account
+            </button>
+          ) : (
+            <div className="space-y-3 border border-red-200 rounded-xl p-4 bg-red-50">
+              <div className="flex items-start gap-2 text-red-700">
+                <AlertTriangle size={16} className="mt-0.5 shrink-0" />
+                <p className="text-sm font-medium">
+                  This will permanently delete your account, all workout sessions, measurements, and logs. This cannot be undone.
+                </p>
+              </div>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => setConfirmDelete(false)}
+                  className="flex-1 py-2 rounded-xl border border-[var(--color-border)] text-sm font-semibold text-[var(--color-muted)] hover:bg-[var(--color-bg)] transition-colors"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleErase}
+                  disabled={deleting}
+                  className="flex-1 py-2 rounded-xl bg-red-500 text-white text-sm font-semibold disabled:opacity-40"
+                >
+                  {deleting ? 'Deleting…' : 'Yes, delete everything'}
+                </button>
+              </div>
+            </div>
+          )}
+
+          {gdprErr && <p className="text-sm text-red-500">{gdprErr}</p>}
+        </Section>
+
+      </main>
+    </div>
+  )
+}


### PR DESCRIPTION
Adds /settings route with three sections: profile editing (display name, birth year, sex, height pre-populated from GET /api/profile), password change form, and data & privacy controls (export download + account deletion with confirmation). Settings accessible from sidebar on desktop and gear icon in mobile header. Bundles api/profile.ts and api/gdpr.ts.

Closes #152
Closes #154