### PR TITLE
feat: admin panel UI — user list, invite, disable/enable, delete

### DIFF
--- a/backend/routers/profile.py
+++ b/backend/routers/profile.py
@@ -18,6 +18,7 @@ class ProfileOut(BaseModel):
     birth_year: int | None
     sex: str | None
     height_cm: float | None
+    is_admin: bool
 
 
 class ProfilePatch(BaseModel):

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import ProgressPage from './pages/ProgressPage'
 import LibraryPage from './pages/LibraryPage'
 import CardioPage from './pages/CardioPage'
 import SettingsPage from './pages/SettingsPage'
+import AdminPage from './pages/AdminPage'
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   if (!Boolean(getToken())) return <Navigate to="/login" replace />
@@ -55,6 +56,7 @@ export default function App() {
         <Route path="/library" element={<ProtectedRoute><LibraryPage /></ProtectedRoute>} />
         <Route path="/cardio" element={<ProtectedRoute><CardioPage /></ProtectedRoute>} />
         <Route path="/settings" element={<ProtectedRoute><SettingsPage /></ProtectedRoute>} />
+        <Route path="/admin" element={<ProtectedRoute><AdminPage /></ProtectedRoute>} />
         <Route path="*" element={<Navigate to={Boolean(getToken()) ? '/' : '/login'} replace />} />
       </Routes>
     </BrowserRouter>

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -1,0 +1,39 @@
+import { request } from './client'
+
+export interface AdminUser {
+  id: number
+  username: string
+  email: string | null
+  display_name: string | null
+  is_active: boolean
+  is_admin: boolean
+  created_at: string
+}
+
+export function listUsers(): Promise<AdminUser[]> {
+  return request<AdminUser[]>('/api/admin/users')
+}
+
+export function createUser(data: {
+  username: string
+  password: string
+  email?: string | null
+  display_name?: string | null
+  is_admin?: boolean
+}): Promise<AdminUser> {
+  return request<AdminUser>('/api/admin/users', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  })
+}
+
+export function patchUser(id: number, data: { is_active?: boolean; is_admin?: boolean }): Promise<AdminUser> {
+  return request<AdminUser>(`/api/admin/users/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(data),
+  })
+}
+
+export function deleteUser(id: number): Promise<void> {
+  return request<void>(`/api/admin/users/${id}`, { method: 'DELETE' })
+}

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1,0 +1,295 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { ArrowLeft, Trash2, UserPlus, ShieldCheck, ShieldOff, ToggleLeft, ToggleRight } from 'lucide-react'
+import { listUsers, createUser, patchUser, deleteUser, type AdminUser } from '../api/admin'
+import { getProfile } from '../api/profile'
+
+const inputCls = 'w-full px-3 py-2 rounded-xl border border-[var(--color-border)] bg-[var(--color-bg)] text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]'
+const labelCls = 'text-xs text-[var(--color-muted)] mb-1.5 block'
+
+export default function AdminPage() {
+  const navigate = useNavigate()
+  const [currentUserId, setCurrentUserId] = useState<number | null>(null)
+  const [users, setUsers] = useState<AdminUser[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  // Invite form
+  const [showInvite, setShowInvite] = useState(false)
+  const [inviteUsername, setInviteUsername] = useState('')
+  const [invitePassword, setInvitePassword] = useState('')
+  const [inviteDisplayName, setInviteDisplayName] = useState('')
+  const [inviteIsAdmin, setInviteIsAdmin] = useState(false)
+  const [inviteSaving, setInviteSaving] = useState(false)
+  const [inviteMsg, setInviteMsg] = useState<{ type: 'ok' | 'err'; text: string } | null>(null)
+
+  // Delete confirmation
+  const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null)
+  const [deleting, setDeleting] = useState(false)
+
+  useEffect(() => {
+    Promise.all([getProfile(), listUsers()])
+      .then(([profile, userList]) => {
+        // We need the current user's id — fetch it from the user list by username
+        const me = userList.find(u => u.username === profile.username)
+        setCurrentUserId(me?.id ?? null)
+        setUsers(userList)
+      })
+      .catch(() => setError('Failed to load users.'))
+      .finally(() => setLoading(false))
+  }, [])
+
+  async function handleInvite() {
+    setInviteMsg(null)
+    setInviteSaving(true)
+    try {
+      const newUser = await createUser({
+        username: inviteUsername,
+        password: invitePassword,
+        display_name: inviteDisplayName || null,
+        is_admin: inviteIsAdmin,
+      })
+      setUsers(prev => [...prev, newUser])
+      setInviteUsername('')
+      setInvitePassword('')
+      setInviteDisplayName('')
+      setInviteIsAdmin(false)
+      setShowInvite(false)
+      setInviteMsg({ type: 'ok', text: `User "${newUser.username}" created.` })
+    } catch (err) {
+      setInviteMsg({ type: 'err', text: err instanceof Error ? err.message : 'Failed to create user.' })
+    } finally {
+      setInviteSaving(false)
+    }
+  }
+
+  async function handleToggleActive(user: AdminUser) {
+    try {
+      const updated = await patchUser(user.id, { is_active: !user.is_active })
+      setUsers(prev => prev.map(u => u.id === updated.id ? updated : u))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Update failed.')
+    }
+  }
+
+  async function handleToggleAdmin(user: AdminUser) {
+    try {
+      const updated = await patchUser(user.id, { is_admin: !user.is_admin })
+      setUsers(prev => prev.map(u => u.id === updated.id ? updated : u))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Update failed.')
+    }
+  }
+
+  async function handleDelete(id: number) {
+    setDeleting(true)
+    try {
+      await deleteUser(id)
+      setUsers(prev => prev.filter(u => u.id !== id))
+      setConfirmDeleteId(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Delete failed.')
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen pb-8">
+      <header className="px-4 pt-12 pb-6 flex items-center gap-3">
+        <button onClick={() => navigate(-1)} className="text-[var(--color-muted)] md:hidden">
+          <ArrowLeft size={20} />
+        </button>
+        <h1 className="text-2xl font-bold tracking-tight">Admin</h1>
+        <span className="ml-1 px-2 py-0.5 rounded-full bg-[var(--color-accent-soft)] text-[var(--color-accent)] text-xs font-semibold">
+          Admin
+        </span>
+      </header>
+
+      <main className="px-4 space-y-6">
+
+        {error && (
+          <p className="text-sm text-red-500">{error}</p>
+        )}
+
+        {/* User list */}
+        <section className="bg-[var(--color-surface)] rounded-2xl border border-[var(--color-border)] overflow-hidden">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--color-border)]">
+            <h2 className="text-base font-semibold">Users</h2>
+            <button
+              onClick={() => { setShowInvite(v => !v); setInviteMsg(null) }}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl bg-[var(--color-accent)] text-white text-sm font-semibold"
+            >
+              <UserPlus size={14} />
+              Invite
+            </button>
+          </div>
+
+          {/* Invite form */}
+          {showInvite && (
+            <div className="px-4 py-4 border-b border-[var(--color-border)] space-y-3 bg-[var(--color-bg)]">
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className={labelCls}>Username</label>
+                  <input
+                    type="text"
+                    value={inviteUsername}
+                    onChange={e => setInviteUsername(e.target.value)}
+                    className={inputCls}
+                    autoComplete="off"
+                  />
+                </div>
+                <div>
+                  <label className={labelCls}>Temporary password</label>
+                  <input
+                    type="text"
+                    value={invitePassword}
+                    onChange={e => setInvitePassword(e.target.value)}
+                    className={inputCls}
+                    autoComplete="off"
+                  />
+                </div>
+              </div>
+              <div>
+                <label className={labelCls}>Display name (optional)</label>
+                <input
+                  type="text"
+                  value={inviteDisplayName}
+                  onChange={e => setInviteDisplayName(e.target.value)}
+                  className={inputCls}
+                />
+              </div>
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={inviteIsAdmin}
+                  onChange={e => setInviteIsAdmin(e.target.checked)}
+                  className="accent-[var(--color-accent)]"
+                />
+                <span className="text-sm text-[var(--color-muted)]">Grant admin access</span>
+              </label>
+              {inviteMsg && (
+                <p className={`text-sm ${inviteMsg.type === 'ok' ? 'text-green-600' : 'text-red-500'}`}>
+                  {inviteMsg.text}
+                </p>
+              )}
+              <div className="flex gap-2">
+                <button
+                  onClick={() => setShowInvite(false)}
+                  className="flex-1 py-2 rounded-xl border border-[var(--color-border)] text-sm font-semibold text-[var(--color-muted)]"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleInvite}
+                  disabled={inviteSaving || !inviteUsername || invitePassword.length < 8}
+                  className="flex-1 py-2 rounded-xl bg-[var(--color-accent)] text-white text-sm font-semibold disabled:opacity-40"
+                >
+                  {inviteSaving ? 'Creating…' : 'Create user'}
+                </button>
+              </div>
+            </div>
+          )}
+
+          {inviteMsg?.type === 'ok' && !showInvite && (
+            <p className="px-4 py-2 text-sm text-green-600 border-b border-[var(--color-border)]">{inviteMsg.text}</p>
+          )}
+
+          {/* User rows */}
+          {loading ? (
+            <p className="px-4 py-6 text-sm text-[var(--color-muted)]">Loading…</p>
+          ) : (
+            <ul className="divide-y divide-[var(--color-border)]">
+              {users.map(user => (
+                <li key={user.id} className="px-4 py-3">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="text-sm font-semibold text-[var(--color-text)] truncate">
+                          {user.username}
+                        </span>
+                        {user.display_name && (
+                          <span className="text-xs text-[var(--color-muted)]">{user.display_name}</span>
+                        )}
+                        {user.is_admin && (
+                          <span className="px-1.5 py-0.5 rounded-full bg-[var(--color-accent-soft)] text-[var(--color-accent)] text-[10px] font-semibold">
+                            Admin
+                          </span>
+                        )}
+                        {!user.is_active && (
+                          <span className="px-1.5 py-0.5 rounded-full bg-gray-100 text-gray-400 text-[10px] font-semibold">
+                            Disabled
+                          </span>
+                        )}
+                      </div>
+                      <p className="text-xs text-[var(--color-muted)] mt-0.5">
+                        Joined {user.created_at.slice(0, 10)}
+                        {user.email && ` · ${user.email}`}
+                      </p>
+                    </div>
+
+                    {/* Actions — hidden for self */}
+                    {user.id !== currentUserId && (
+                      <div className="flex items-center gap-1 shrink-0">
+                        <button
+                          onClick={() => handleToggleActive(user)}
+                          title={user.is_active ? 'Disable account' : 'Enable account'}
+                          className="p-1.5 rounded-lg text-[var(--color-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg)] transition-colors"
+                        >
+                          {user.is_active
+                            ? <ToggleRight size={18} className="text-green-500" />
+                            : <ToggleLeft size={18} />
+                          }
+                        </button>
+                        <button
+                          onClick={() => handleToggleAdmin(user)}
+                          title={user.is_admin ? 'Remove admin' : 'Make admin'}
+                          className="p-1.5 rounded-lg text-[var(--color-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg)] transition-colors"
+                        >
+                          {user.is_admin
+                            ? <ShieldCheck size={18} className="text-[var(--color-accent)]" />
+                            : <ShieldOff size={18} />
+                          }
+                        </button>
+                        <button
+                          onClick={() => setConfirmDeleteId(user.id)}
+                          title="Delete user"
+                          className="p-1.5 rounded-lg text-[var(--color-muted)] hover:text-red-500 hover:bg-red-50 transition-colors"
+                        >
+                          <Trash2 size={16} />
+                        </button>
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Delete confirmation inline */}
+                  {confirmDeleteId === user.id && (
+                    <div className="mt-3 flex items-center gap-2 p-3 rounded-xl border border-red-200 bg-red-50">
+                      <p className="text-xs text-red-700 flex-1">
+                        Delete <strong>{user.username}</strong> and all their data?
+                      </p>
+                      <button
+                        onClick={() => setConfirmDeleteId(null)}
+                        className="px-3 py-1.5 rounded-lg border border-[var(--color-border)] text-xs font-semibold text-[var(--color-muted)]"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        onClick={() => handleDelete(user.id)}
+                        disabled={deleting}
+                        className="px-3 py-1.5 rounded-lg bg-red-500 text-white text-xs font-semibold disabled:opacity-40"
+                      >
+                        {deleting ? '…' : 'Delete'}
+                      </button>
+                    </div>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+      </main>
+    </div>
+  )
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
-import { ArrowLeft, Download, Trash2, AlertTriangle } from 'lucide-react'
+import { useNavigate, Link } from 'react-router-dom'
+import { ArrowLeft, Download, Trash2, AlertTriangle, ShieldCheck } from 'lucide-react'
 import { getProfile, updateProfile, changePassword, type Profile } from '../api/profile'
 import { exportData, eraseAccount } from '../api/gdpr'
 import { logout } from '../api/auth'
@@ -146,6 +146,20 @@ export default function SettingsPage() {
       </header>
 
       <main className="px-4 space-y-6">
+
+        {/* Admin panel link — only for admins */}
+        {profile?.is_admin && (
+          <Link
+            to="/admin"
+            className="flex items-center justify-between px-4 py-3 bg-[var(--color-surface)] rounded-2xl border border-[var(--color-border)] hover:bg-[var(--color-bg)] transition-colors"
+          >
+            <div className="flex items-center gap-3">
+              <ShieldCheck size={18} className="text-[var(--color-accent)]" />
+              <span className="text-sm font-semibold text-[var(--color-text)]">Admin panel</span>
+            </div>
+            <span className="text-xs text-[var(--color-muted)]">Manage users →</span>
+          </Link>
+        )}
 
         {/* Profile */}
         <Section title="Profile">


### PR DESCRIPTION
Adds /admin route with full user management: list all users with joined date and status badges, invite form with optional admin grant, inline active/admin toggles, and per-user delete confirmation. Admin panel link visible in Settings only for admin users. Adds is_admin to ProfileOut so the frontend can gate admin-only UI.

Closes #153