### PR TITLE
fix: surface network errors and add loading state in frontend (#185)

### DIFF
--- a/frontend/src/pages/ActiveWorkoutPage.tsx
+++ b/frontend/src/pages/ActiveWorkoutPage.tsx
@@ -67,6 +67,8 @@ export default function ActiveWorkoutPage() {
   const [lastSets, setLastSets] = useState<Record<number, LogEntry | null>>({})
   const [sets, setSets] = useState<Record<number, SetRow[]>>({})
   const [rest, setRest] = useState(0)
+  const [exercisesLoading, setExercisesLoading] = useState(true)
+  const [setLogError, setSetLogError] = useState<string | null>(null)
   const [showSummary, setShowSummary] = useState(false)
   const [finishing, setFinishing] = useState(false)
 
@@ -88,45 +90,48 @@ export default function ActiveWorkoutPage() {
   // Load exercises, previous sets, and any already-completed sets for this session
   useEffect(() => {
     if (!session) { navigate('/'); return }
-    Promise.all([getExercises(session), getSessionLogs(id)]).then(([exs, currentLogs]) => {
-      setExercises(exs)
+    Promise.all([getExercises(session), getSessionLogs(id)])
+      .then(([exs, currentLogs]) => {
+        setExercises(exs)
 
-      const logsByExercise: Record<number, SessionLogEntry[]> = {}
-      for (const log of currentLogs) {
-        ;(logsByExercise[log.exercise_id] ??= []).push(log)
-      }
+        const logsByExercise: Record<number, SessionLogEntry[]> = {}
+        for (const log of currentLogs) {
+          ;(logsByExercise[log.exercise_id] ??= []).push(log)
+        }
 
-      Promise.all(exs.map(e => getLastSet(e.id))).then(results => {
-        const lastMap: Record<number, LogEntry | null> = {}
-        const setsMap: Record<number, SetRow[]> = {}
-        exs.forEach((e, i) => {
-          const last = results[i]
-          lastMap[e.id] = last
+        return Promise.all(exs.map(e => getLastSet(e.id))).then(results => {
+          const lastMap: Record<number, LogEntry | null> = {}
+          const setsMap: Record<number, SetRow[]> = {}
+          exs.forEach((e, i) => {
+            const last = results[i]
+            lastMap[e.id] = last
 
-          const doneLogs = logsByExercise[e.id] ?? []
-          const doneRows: SetRow[] = doneLogs.map(log => ({
-            weight: String(log.weight),
-            reps: String(log.reps),
-            done: true,
-            logEntry: log as unknown as LogEntry,
-          }))
+            const doneLogs = logsByExercise[e.id] ?? []
+            const doneRows: SetRow[] = doneLogs.map(log => ({
+              weight: String(log.weight),
+              reps: String(log.reps),
+              done: true,
+              logEntry: log as unknown as LogEntry,
+            }))
 
-          const lastDone = doneLogs[doneLogs.length - 1]
-          const prefill = lastDone
-            ? { weight: String(lastDone.weight), reps: String(lastDone.reps) }
-            : { weight: last ? String(last.weight) : '', reps: last ? String(last.reps) : '' }
+            const lastDone = doneLogs[doneLogs.length - 1]
+            const prefill = lastDone
+              ? { weight: String(lastDone.weight), reps: String(lastDone.reps) }
+              : { weight: last ? String(last.weight) : '', reps: last ? String(last.reps) : '' }
 
-          const emptyCount = Math.max(3, doneLogs.length + 1) - doneRows.length
-          const emptyRows: SetRow[] = Array.from({ length: emptyCount }, () => ({
-            ...prefill, done: false, logEntry: null,
-          }))
+            const emptyCount = Math.max(3, doneLogs.length + 1) - doneRows.length
+            const emptyRows: SetRow[] = Array.from({ length: emptyCount }, () => ({
+              ...prefill, done: false, logEntry: null,
+            }))
 
-          setsMap[e.id] = [...doneRows, ...emptyRows]
+            setsMap[e.id] = [...doneRows, ...emptyRows]
+          })
+          setLastSets(lastMap)
+          setSets(setsMap)
         })
-        setLastSets(lastMap)
-        setSets(setsMap)
       })
-    })
+      .catch(() => {})
+      .finally(() => setExercisesLoading(false))
   }, [session])
 
   function updateSet(exerciseId: number, si: number, field: 'weight' | 'reps', value: string) {
@@ -151,7 +156,10 @@ export default function ActiveWorkoutPage() {
         return { ...prev, [exerciseId]: exSets }
       })
       setRest(90)
-    } catch { /* leave undone on failure */ }
+    } catch {
+      setSetLogError('Set not saved — please retry.')
+      setTimeout(() => setSetLogError(null), 4000)
+    }
   }
 
   function addSet(exerciseId: number) {
@@ -250,7 +258,18 @@ export default function ActiveWorkoutPage() {
           </div>
         )}
 
+        {setLogError && (
+          <div className="flex items-center gap-3 px-4 py-3 rounded-[14px] bg-red-50 border border-red-200 text-red-600 text-sm font-semibold">
+            {setLogError}
+          </div>
+        )}
+
         {/* Exercise cards — 2-col on desktop */}
+        {exercisesLoading ? (
+          <div className="flex items-center justify-center py-16 text-sm text-[var(--color-muted)] font-semibold">
+            Loading exercises…
+          </div>
+        ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-[14px]">
           {exercises.map(ex => {
             const exSets = sets[ex.id] ?? []
@@ -352,6 +371,7 @@ export default function ActiveWorkoutPage() {
             )
           })}
         </div>
+        )}
 
         {/* Bottom finish button */}
         <button

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -49,10 +49,12 @@ export default function HomePage() {
   const [sessions, setSessions] = useState<string[]>([])
   const [starting, setStarting] = useState<string | null>(null)
   const [stats, setStats] = useState<HomeStats | null>(null)
+  const [loadError, setLoadError] = useState(false)
 
   useEffect(() => {
-    getSessions().then(setSessions)
-    getHomeStats().then(setStats)
+    Promise.all([getSessions(), getHomeStats()])
+      .then(([s, h]) => { setSessions(s); setStats(h) })
+      .catch(() => setLoadError(true))
   }, [])
 
   async function handleStart(session: string) {
@@ -81,6 +83,12 @@ export default function HomePage() {
       </header>
 
       <main className="px-4 space-y-4">
+
+        {loadError && (
+          <p className="text-sm text-red-500 bg-red-50 border border-red-200 rounded-xl px-4 py-3">
+            Could not load data — please check your connection and try again.
+          </p>
+        )}
 
         {/* Stats grid */}
         {stats && (

--- a/frontend/src/pages/ProgressPage.tsx
+++ b/frontend/src/pages/ProgressPage.tsx
@@ -83,6 +83,7 @@ export default function ProgressPage() {
   const [consistency, setConsistency] = useState<ConsistencyWeek[]>([])
   const [balance, setBalance] = useState<MuscleBalance[]>([])
   const [measurements, setMeasurements] = useState<Measurement[]>([])
+  const [loadError, setLoadError] = useState(false)
   const [showLogForm, setShowLogForm] = useState(false)
   const [weightInput, setWeightInput] = useState('')
   const [fatInput, setFatInput] = useState('')
@@ -90,18 +91,24 @@ export default function ProgressPage() {
   const [saving, setSaving] = useState(false)
 
   useEffect(() => {
-    getPRs().then(data => {
-      setPRs(data)
-      if (data.length > 0) setSelectedExerciseId(data[0].exercise_id)
-    })
-    getVolume().then(setVolume)
-    getConsistency().then(setConsistency)
-    getBalance().then(setBalance)
-    getMeasurements().then(setMeasurements)
+    Promise.all([getPRs(), getVolume(), getConsistency(), getBalance(), getMeasurements()])
+      .then(([prsData, vol, cons, bal, meas]) => {
+        setPRs(prsData)
+        if (prsData.length > 0) setSelectedExerciseId(prsData[0].exercise_id)
+        setVolume(vol)
+        setConsistency(cons)
+        setBalance(bal)
+        setMeasurements(meas)
+      })
+      .catch(() => setLoadError(true))
   }, [])
 
   useEffect(() => {
-    if (selectedExerciseId !== null) getStrengthProgression(selectedExerciseId).then(setStrengthData)
+    if (selectedExerciseId !== null) {
+      getStrengthProgression(selectedExerciseId)
+        .then(setStrengthData)
+        .catch(() => {})
+    }
   }, [selectedExerciseId])
 
   // Range filter
@@ -180,6 +187,12 @@ export default function ProgressPage() {
       </header>
 
       <main className="px-4 pt-4 space-y-4">
+
+        {loadError && (
+          <p className="text-sm text-red-500 bg-red-50 border border-red-200 rounded-xl px-4 py-3">
+            Could not load data — please check your connection and try again.
+          </p>
+        )}
 
         {/* Strength */}
         <Card className="!p-[22px]">


### PR DESCRIPTION
ProgressPage and HomePage both had fire-and-forget .then() chains with no error handling. A network failure silently left both pages blank with no user feedback.

Wrapped both pages' initial data fetches in Promise.all with a .catch() that sets a loadError flag, rendering an inline red banner ("Could not load data — please check your connection and try again.").

ActiveWorkoutPage had two issues: the exercise fetch had no loading state, causing an empty grid flash before data arrived; and set-logging failures were silently swallowed with a comment. Added exercisesLoading state that shows a "Loading exercises…" placeholder until data is ready, and replaced the silent catch with setLogError that displays a banner for 4 seconds before auto-clearing.

Closes #185