### PR TITLE
feat: FAB speed-dial, session picker sheet, and quick start card (#115)

### DIFF
--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -1,6 +1,8 @@
+import { useEffect, useState } from 'react'
 import { NavLink, useNavigate, useLocation } from 'react-router-dom'
-import { House, TrendingUp, Clock, BookOpen, Plus, Play } from 'lucide-react'
+import { House, TrendingUp, Clock, BookOpen, Plus, Play, Settings, Dumbbell } from 'lucide-react'
 import { getActiveWorkout } from '../api/workoutSessions'
+import SessionPickerSheet from './SessionPickerSheet'
 
 const LEFT  = [
   { label: 'Home',     icon: House,      path: '/' },
@@ -12,10 +14,48 @@ const RIGHT = [
 ]
 
 export default function BottomNav() {
-  const navigate = useNavigate()
-  useLocation() // re-render on every navigation to pick up localStorage changes
+  const navigate  = useNavigate()
+  const location  = useLocation()
 
   const active = getActiveWorkout()
+  const [fabOpen, setFabOpen]     = useState(false)
+  const [showPicker, setShowPicker] = useState(false)
+
+  // Close speed-dial whenever the route changes (nav tab tap, etc.)
+  useEffect(() => { setFabOpen(false) }, [location.pathname])
+
+  const menuItems = active
+    ? [
+        {
+          label: 'Continue workout',
+          Icon: Play,
+          accent: true,
+          action: () => {
+            setFabOpen(false)
+            navigate(`/workout/${active.id}`, { state: { session: active.session, sessionId: active.id } })
+          },
+        },
+        {
+          label: 'Settings',
+          Icon: Settings,
+          accent: false,
+          action: () => { setFabOpen(false); navigate('/settings') },
+        },
+      ]
+    : [
+        {
+          label: 'Start workout',
+          Icon: Dumbbell,
+          accent: true,
+          action: () => { setFabOpen(false); setShowPicker(true) },
+        },
+        {
+          label: 'Settings',
+          Icon: Settings,
+          accent: false,
+          action: () => { setFabOpen(false); navigate('/settings') },
+        },
+      ]
 
   const tab = (label: string, Icon: React.ElementType, path: string) => (
     <NavLink
@@ -38,31 +78,89 @@ export default function BottomNav() {
   )
 
   return (
-    <nav
-      className="md:hidden relative z-30 shrink-0 flex justify-around items-stretch px-[10px] pt-[9px] pb-[26px] border-t border-[var(--color-border)]"
-      style={{ background: 'rgba(255,255,255,0.86)', backdropFilter: 'blur(18px) saturate(180%)', WebkitBackdropFilter: 'blur(18px) saturate(180%)' }}
-    >
-      {LEFT.map(({ label, icon, path }) => tab(label, icon, path))}
+    <>
+      {showPicker && <SessionPickerSheet onClose={() => setShowPicker(false)} />}
 
-      {/* Centre FAB */}
-      <div className="flex flex-col items-center gap-1 flex-1 text-[10.5px] font-semibold" style={{ marginTop: -34 }}>
-        <button
-          onClick={() => active ? navigate(`/workout/${active.id}`, { state: { session: active.session, sessionId: active.id } }) : navigate('/')}
-          className="w-[52px] h-[52px] rounded-full bg-[var(--color-accent)] flex items-center justify-center"
-          style={{ boxShadow: 'color-mix(in srgb, var(--color-accent) 42%, transparent) 0 8px 20px' }}
-          aria-label={active ? 'Resume workout' : 'Start workout'}
+      {/* Backdrop — below nav (z-[25]) so the nav stays visible above it */}
+      {fabOpen && (
+        <div
+          className="fixed inset-0 z-[25] bg-black/20"
+          onClick={() => setFabOpen(false)}
+        />
+      )}
+
+      <nav
+        className="md:hidden relative z-30 shrink-0 flex justify-around items-stretch px-[10px] pt-[9px] pb-[26px] border-t border-[var(--color-border)]"
+        style={{ background: 'rgba(255,255,255,0.86)', backdropFilter: 'blur(18px) saturate(180%)', WebkitBackdropFilter: 'blur(18px) saturate(180%)' }}
+      >
+        {LEFT.map(({ label, icon, path }) => tab(label, icon, path))}
+
+        {/* Centre FAB */}
+        <div
+          className="flex flex-col items-center gap-1 flex-1 text-[10.5px] font-semibold"
+          style={{ marginTop: -34 }}
         >
-          {active
-            ? <Play size={22} strokeWidth={2.4} color="#fff" fill="#fff" />
-            : <Plus size={26} strokeWidth={2.4} color="#fff" />
-          }
-        </button>
-        <span className={active ? 'text-[var(--color-accent)]' : 'text-[var(--color-faint)]'}>
-          {active ? 'Resume' : 'Start'}
-        </span>
-      </div>
+          {/* Inner relative wrapper so bottom-full anchors to the button top */}
+          <div className="relative">
 
-      {RIGHT.map(({ label, icon, path }) => tab(label, icon, path))}
-    </nav>
+            {/* Speed-dial items — positioned above the FAB button */}
+            {fabOpen && (
+              <div className="absolute bottom-full mb-3 left-1/2 -translate-x-1/2 flex flex-col items-end gap-3 z-30">
+                {menuItems.map((item, i) => (
+                  <button
+                    key={i}
+                    onClick={item.action}
+                    className="flex items-center gap-2 group"
+                  >
+                    <span
+                      className="text-[12px] font-semibold text-[var(--color-text)] bg-white/95 rounded-xl px-3 py-1.5 border border-[var(--color-border)] whitespace-nowrap group-hover:bg-[var(--color-bg)] transition-colors"
+                      style={{ boxShadow: '0 2px 8px rgba(0,0,0,.08)' }}
+                    >
+                      {item.label}
+                    </span>
+                    <div
+                      className={`w-[44px] h-[44px] rounded-full flex items-center justify-center shrink-0 ${
+                        item.accent
+                          ? 'bg-[var(--color-accent)]'
+                          : 'bg-[var(--color-surface)] border border-[var(--color-border)]'
+                      }`}
+                      style={{ boxShadow: item.accent ? 'color-mix(in srgb, var(--color-accent) 35%, transparent) 0 4px 14px' : '0 2px 8px rgba(0,0,0,.08)' }}
+                    >
+                      <item.Icon
+                        size={19}
+                        strokeWidth={2.2}
+                        color={item.accent ? '#fff' : undefined}
+                        className={item.accent ? '' : 'text-[var(--color-text)]'}
+                      />
+                    </div>
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {/* FAB button */}
+            <button
+              onClick={() => setFabOpen(v => !v)}
+              className="w-[52px] h-[52px] rounded-full bg-[var(--color-accent)] flex items-center justify-center focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-accent)]"
+              style={{ boxShadow: 'color-mix(in srgb, var(--color-accent) 42%, transparent) 0 8px 20px' }}
+              aria-label={fabOpen ? 'Close menu' : 'Open workout menu'}
+            >
+              <Plus
+                size={26}
+                strokeWidth={2.4}
+                color="#fff"
+                style={{ transform: fabOpen ? 'rotate(45deg)' : 'rotate(0deg)', transition: 'transform 0.2s ease' }}
+              />
+            </button>
+          </div>
+
+          <span className={active && !fabOpen ? 'text-[var(--color-accent)]' : 'text-[var(--color-faint)]'}>
+            {fabOpen ? ' ' : active ? 'Resume' : 'Start'}
+          </span>
+        </div>
+
+        {RIGHT.map(({ label, icon, path }) => tab(label, icon, path))}
+      </nav>
+    </>
   )
 }

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,5 +1,3 @@
-import { NavLink } from 'react-router-dom'
-import { Settings } from 'lucide-react'
 import Sidebar from './Sidebar'
 import BottomNav from './BottomNav'
 
@@ -8,12 +6,6 @@ export default function Layout({ children }: { children: React.ReactNode }) {
     <div className="flex h-full">
       <Sidebar />
       <div className="flex flex-col flex-1 min-w-0 min-h-0">
-        {/* Mobile-only settings access */}
-        <div className="md:hidden flex justify-end px-4 py-3 border-b border-[var(--color-border)] bg-[var(--color-surface)]">
-          <NavLink to="/settings" className={({ isActive }) => isActive ? 'text-[var(--color-accent)]' : 'text-[var(--color-muted)]'}>
-            <Settings size={20} />
-          </NavLink>
-        </div>
         <div className="flex-1 overflow-y-auto">
           {children}
         </div>

--- a/frontend/src/components/SessionPickerSheet.tsx
+++ b/frontend/src/components/SessionPickerSheet.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Dumbbell, X } from 'lucide-react'
+import { getSessions } from '../api/exercises'
+import { startSession, saveActiveWorkout } from '../api/workoutSessions'
+
+const SESSION_META: Record<string, string> = {
+  'Push A': 'Chest · Shoulders · Triceps',
+  'Pull A': 'Back · Biceps · Rear Delts',
+  'Legs A': 'Quads · Glutes · Hamstrings',
+}
+
+interface Props {
+  onClose: () => void
+}
+
+export default function SessionPickerSheet({ onClose }: Props) {
+  const navigate = useNavigate()
+  const [sessions, setSessions] = useState<string[]>([])
+  const [starting, setStarting] = useState<string | null>(null)
+
+  useEffect(() => {
+    getSessions().then(setSessions).catch(() => {})
+  }, [])
+
+  async function handleStart(session: string) {
+    setStarting(session)
+    try {
+      const workout = await startSession(session)
+      saveActiveWorkout(workout.id, session, workout.started_at)
+      onClose()
+      navigate(`/workout/${workout.id}`, { state: { session, sessionId: workout.id } })
+    } finally {
+      setStarting(null)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col justify-end">
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+      <div className="relative bg-[var(--color-surface)] rounded-t-[24px] px-4 pt-5 pb-8 space-y-3">
+        <div className="flex items-center justify-between mb-1">
+          <h2 className="text-[17px] font-bold">Start workout</h2>
+          <button
+            onClick={onClose}
+            className="w-8 h-8 rounded-full bg-[var(--color-bg)] flex items-center justify-center text-[var(--color-muted)]"
+          >
+            <X size={16} />
+          </button>
+        </div>
+        {sessions.map(session => (
+          <button
+            key={session}
+            onClick={() => handleStart(session)}
+            disabled={starting !== null}
+            className="w-full flex items-center gap-4 p-4 bg-[var(--color-bg)] rounded-2xl border border-[var(--color-border)] hover:border-[var(--color-accent)] transition-colors disabled:opacity-50 text-left"
+          >
+            <div className="w-10 h-10 rounded-xl bg-[var(--color-accent-soft)] flex items-center justify-center shrink-0">
+              <Dumbbell size={18} className="text-[var(--color-accent)]" />
+            </div>
+            <div className="flex-1">
+              <p className="font-semibold text-[var(--color-text)]">{session}</p>
+              {SESSION_META[session] && (
+                <p className="text-xs text-[var(--color-muted)] mt-0.5">{SESSION_META[session]}</p>
+              )}
+            </div>
+            {starting === session && (
+              <span className="text-sm text-[var(--color-muted)] shrink-0">Starting…</span>
+            )}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Dumbbell, Activity, Flame, Zap, Clock } from 'lucide-react'
+import { Dumbbell, Activity, Flame, Zap, Clock, Play } from 'lucide-react'
 import { getSessions } from '../api/exercises'
-import { startSession, saveActiveWorkout } from '../api/workoutSessions'
+import { startSession, saveActiveWorkout, getActiveWorkout } from '../api/workoutSessions'
 import { getHomeStats, type HomeStats } from '../api/stats'
 
 const SESSION_META: Record<string, { focus: string }> = {
@@ -50,6 +50,8 @@ export default function HomePage() {
   const [starting, setStarting] = useState<string | null>(null)
   const [stats, setStats] = useState<HomeStats | null>(null)
   const [loadError, setLoadError] = useState(false)
+
+  const activeWorkout = getActiveWorkout()
 
   useEffect(() => {
     Promise.all([getSessions(), getHomeStats()])
@@ -127,10 +129,59 @@ export default function HomePage() {
           </div>
         )}
 
-        {/* Session cards */}
-        <div
-          className="bg-[var(--color-surface)] border border-[var(--color-border)] rounded-2xl p-4 flex items-center justify-between"
-        >
+        {/* Quick start / Resume */}
+        {sessions.length > 0 && (
+          activeWorkout ? (
+            <div className="bg-[var(--color-surface)] border border-[var(--color-border)] rounded-2xl overflow-hidden">
+              <div className="px-4 py-3 border-b border-[var(--color-border)]">
+                <p className="font-semibold text-[var(--color-text)]">Active workout</p>
+                <p className="text-xs text-[var(--color-muted)] mt-0.5">You have a session in progress</p>
+              </div>
+              <button
+                onClick={() => navigate(`/workout/${activeWorkout.id}`, { state: { session: activeWorkout.session, sessionId: activeWorkout.id } })}
+                className="w-full flex items-center gap-3 px-4 py-3 hover:bg-[var(--color-bg)] transition-colors"
+              >
+                <div className="w-9 h-9 rounded-xl bg-[var(--color-accent-soft)] flex items-center justify-center shrink-0">
+                  <Play size={16} className="text-[var(--color-accent)]" fill="var(--color-accent)" />
+                </div>
+                <div className="flex-1 text-left">
+                  <p className="text-sm font-semibold text-[var(--color-text)]">{activeWorkout.session}</p>
+                  <p className="text-xs text-[var(--color-muted)]">In progress</p>
+                </div>
+                <span className="text-xs font-semibold text-[var(--color-accent)] shrink-0">Resume →</span>
+              </button>
+            </div>
+          ) : (
+            <div className="bg-[var(--color-surface)] border border-[var(--color-border)] rounded-2xl overflow-hidden">
+              <div className="px-4 py-3 border-b border-[var(--color-border)]">
+                <p className="font-semibold text-[var(--color-text)]">Quick start</p>
+                <p className="text-xs text-[var(--color-muted)] mt-0.5">Tap a session or use the + button</p>
+              </div>
+              {sessions.map(session => (
+                <button
+                  key={session}
+                  onClick={() => handleStart(session)}
+                  disabled={starting !== null}
+                  className="w-full flex items-center gap-3 px-4 py-3 border-b border-[var(--color-border)] last:border-b-0 hover:bg-[var(--color-bg)] transition-colors disabled:opacity-50"
+                >
+                  <div className="w-9 h-9 rounded-xl bg-[var(--color-accent-soft)] flex items-center justify-center shrink-0">
+                    <Dumbbell size={16} className="text-[var(--color-accent)]" />
+                  </div>
+                  <div className="flex-1 text-left">
+                    <p className="text-sm font-semibold text-[var(--color-text)]">{session}</p>
+                    <p className="text-xs text-[var(--color-muted)]">{SESSION_META[session]?.focus}</p>
+                  </div>
+                  <span className="text-xs font-semibold text-[var(--color-accent)] shrink-0">
+                    {starting === session ? 'Starting…' : 'Start →'}
+                  </span>
+                </button>
+              ))}
+            </div>
+          )
+        )}
+
+        {/* Cardio */}
+        <div className="bg-[var(--color-surface)] border border-[var(--color-border)] rounded-2xl p-4 flex items-center justify-between">
           <div className="flex items-center gap-3">
             <div className="w-10 h-10 rounded-xl bg-[var(--color-accent)] bg-opacity-10 flex items-center justify-center">
               <Activity size={18} className="text-[var(--color-accent)]" />
@@ -147,32 +198,6 @@ export default function HomePage() {
             Log
           </button>
         </div>
-
-        {sessions.map(session => (
-          <div
-            key={session}
-            className="bg-[var(--color-surface)] border border-[var(--color-border)] rounded-2xl p-4 flex items-center justify-between"
-          >
-            <div className="flex items-center gap-3">
-              <div className="w-10 h-10 rounded-xl bg-[var(--color-accent)] bg-opacity-10 flex items-center justify-center">
-                <Dumbbell size={18} className="text-[var(--color-accent)]" />
-              </div>
-              <div>
-                <p className="font-semibold text-[var(--color-text)]">{session}</p>
-                <p className="text-sm text-[var(--color-muted)]">
-                  {SESSION_META[session]?.focus}
-                </p>
-              </div>
-            </div>
-            <button
-              onClick={() => handleStart(session)}
-              disabled={starting !== null}
-              className="px-4 py-2 bg-[var(--color-accent)] text-white text-sm font-semibold rounded-xl disabled:opacity-50"
-            >
-              {starting === session ? '…' : 'Start'}
-            </button>
-          </div>
-        ))}
 
       </main>
     </div>


### PR DESCRIPTION
The FAB was a single-tap button that navigated to Home when no workout was active, requiring two steps to start a session. There was no way to reach Settings from mobile without the now-removed gear icon header bar.

Replaced the FAB with a speed-dial that fans two options upward on tap: "Start workout" and "Settings" when idle; "Continue workout" and "Settings" when a session is active. The FAB rotates 45° to an × when open. Tapping the backdrop or any nav tab closes it automatically via a useEffect on location.pathname. Each speed-dial row (label + icon) is a single button so the whole area is tappable.

"Start workout" opens a new SessionPickerSheet bottom sheet listing all available sessions. Picking one starts the workout directly — one tap instead of two. The three individual session cards on HomePage are consolidated into a single "Quick start" card. When a session is active the Quick start card switches to an "Active workout" resume card, preventing parallel sessions from being started accidentally.

The mobile settings gear icon header bar in Layout is removed; Settings is now accessible via the FAB menu on mobile and the sidebar on desktop.

Closes #115