### PR TITLE
fix: make FinishWorkoutSheet dismissible by tapping outside (#193)

### DIFF
--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -129,6 +129,26 @@ def get_session_logs(
     ]
 
 
+@router.delete("/{session_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_session(
+    session_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    workout = db.get(WorkoutSession, session_id)
+    if not workout or workout.user_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Session not found"
+        )
+    if workout.ended_at:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Session already ended"
+        )
+    db.query(Log).filter(Log.session_id == session_id).delete()
+    db.delete(workout)
+    db.commit()
+
+
 @router.patch("/{session_id}/end", response_model=WorkoutSessionOut)
 def end_session(
     session_id: int,

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -1,4 +1,36 @@
+from datetime import datetime, timezone
+
+import bcrypt
 from fastapi.testclient import TestClient
+
+from database import SessionLocal
+from models.user import User
+
+
+def _create_user_b() -> None:
+    db = SessionLocal()
+    if not db.query(User).filter(User.username == "userb_sessions").first():
+        db.add(
+            User(
+                username="userb_sessions",
+                hashed_password=bcrypt.hashpw(
+                    b"passwordB1", bcrypt.gensalt(rounds=4)
+                ).decode(),
+                is_active=True,
+                is_admin=False,
+                created_at=datetime.now(timezone.utc),
+            )
+        )
+        db.commit()
+    db.close()
+
+
+def _auth_b(client: TestClient) -> dict:
+    _create_user_b()
+    token = client.post(
+        "/api/auth/login", json={"username": "userb_sessions", "password": "passwordB1"}
+    ).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
 
 
 def _token(client: TestClient) -> str:
@@ -171,6 +203,47 @@ def test_list_sessions_single_query(client: TestClient):
 
     assert resp.status_code == 200
     assert query_count <= 2, f"N+1 detected: {query_count} SELECT queries (expected ≤2)"
+
+
+# ── Discard session ───────────────────────────────────────────────────────────
+
+
+def test_delete_active_session_returns_204(client: TestClient):
+    session = _start(client)
+    resp = client.delete(f"/api/sessions/{session['id']}", headers=_auth(client))
+    assert resp.status_code == 204
+    # Session and its logs must be gone
+    logs_resp = client.get(f"/api/sessions/{session['id']}/logs", headers=_auth(client))
+    assert logs_resp.status_code == 404
+
+
+def test_delete_active_session_removes_logs(client: TestClient):
+    exercise_id = _first_exercise_id(client)
+    session = _start(client)
+    _log_set(client, session["id"], exercise_id)
+    _log_set(client, session["id"], exercise_id)
+    resp = client.delete(f"/api/sessions/{session['id']}", headers=_auth(client))
+    assert resp.status_code == 204
+    # Logs endpoint returns 404 (session gone)
+    assert (
+        client.get(
+            f"/api/sessions/{session['id']}/logs", headers=_auth(client)
+        ).status_code
+        == 404
+    )
+
+
+def test_delete_other_users_session_returns_404(client: TestClient):
+    session = _start(client)
+    resp = client.delete(f"/api/sessions/{session['id']}", headers=_auth_b(client))
+    assert resp.status_code == 404
+
+
+def test_delete_ended_session_returns_400(client: TestClient):
+    session = _start(client)
+    client.patch(f"/api/sessions/{session['id']}/end", headers=_auth(client))
+    resp = client.delete(f"/api/sessions/{session['id']}", headers=_auth(client))
+    assert resp.status_code == 400
 
 
 # ── Full flow ─────────────────────────────────────────────────────────────────

--- a/frontend/src/api/workoutSessions.ts
+++ b/frontend/src/api/workoutSessions.ts
@@ -58,3 +58,7 @@ export function endSession(sessionId: number): Promise<WorkoutSession> {
     method: 'PATCH',
   })
 }
+
+export function discardSession(sessionId: number): Promise<void> {
+  return request<void>(`/api/sessions/${sessionId}`, { method: 'DELETE' })
+}

--- a/frontend/src/components/FinishWorkoutSheet.tsx
+++ b/frontend/src/components/FinishWorkoutSheet.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react'
+import { AlertTriangle } from 'lucide-react'
 import type { Exercise } from '../api/exercises'
 import type { LogEntry } from '../api/logs'
 
@@ -6,19 +8,54 @@ interface Props {
   exercises: Exercise[]
   sessionLogs: Record<number, LogEntry[]>
   onConfirm: () => void
+  onDiscard: () => Promise<void>
   onCancel: () => void
   loading: boolean
 }
 
-export default function FinishWorkoutSheet({ session, exercises, sessionLogs, onConfirm, onCancel, loading }: Props) {
+export default function FinishWorkoutSheet({ session, exercises, sessionLogs, onConfirm, onDiscard, onCancel, loading }: Props) {
   const allLogs = Object.values(sessionLogs).flat()
   const totalSets = allLogs.length
   const totalVolume = allLogs.reduce((sum, l) => sum + l.weight * l.reps, 0)
   const exercisesWorked = exercises.filter(e => (sessionLogs[e.id]?.length ?? 0) > 0).length
 
+  const [confirmDiscard, setConfirmDiscard] = useState(false)
+  const [countdown, setCountdown] = useState(0)
+  const [discarding, setDiscarding] = useState(false)
+
+  // Start countdown when discard panel opens; reset when it closes
+  useEffect(() => {
+    if (!confirmDiscard) { setCountdown(0); return }
+    setCountdown(2)
+  }, [confirmDiscard])
+
+  // Decrement countdown each second until zero
+  useEffect(() => {
+    if (countdown <= 0) return
+    const t = setTimeout(() => setCountdown(c => c - 1), 1000)
+    return () => clearTimeout(t)
+  }, [countdown])
+
+  function dismissDiscard() { setConfirmDiscard(false) }
+
+  async function handleDiscard() {
+    setDiscarding(true)
+    try {
+      await onDiscard()
+    } finally {
+      setDiscarding(false)
+    }
+  }
+
   return (
-    <div className="fixed inset-0 bg-black/40 flex items-end z-50">
-      <div className="w-full bg-[var(--color-surface)] rounded-t-3xl px-5 pt-6 pb-10">
+    <div
+      className="fixed inset-0 bg-black/40 flex items-end z-50"
+      onClick={confirmDiscard ? dismissDiscard : onCancel}
+    >
+      <div
+        className="relative w-full bg-[var(--color-surface)] rounded-t-3xl px-5 pt-6 pb-10"
+        onClick={e => e.stopPropagation()}
+      >
         <div className="w-10 h-1 bg-[var(--color-border)] rounded-full mx-auto mb-6" />
 
         <h2 className="text-xl font-bold text-[var(--color-text)]">Finish {session}?</h2>
@@ -38,19 +75,63 @@ export default function FinishWorkoutSheet({ session, exercises, sessionLogs, on
           </div>
         </div>
 
+        {/* Overlay — covers sheet content behind the discard panel */}
+        {confirmDiscard && (
+          <div
+            className="absolute inset-0 z-10 rounded-t-3xl"
+            onClick={dismissDiscard}
+          />
+        )}
+
         <button
           onClick={onConfirm}
-          disabled={loading}
+          disabled={loading || discarding}
           className="mt-5 w-full py-3 bg-[var(--color-accent)] text-white font-semibold rounded-2xl disabled:opacity-50"
         >
           {loading ? 'Saving…' : 'Save & Finish'}
         </button>
         <button
           onClick={onCancel}
+          disabled={loading || discarding}
           className="mt-3 w-full py-3 text-[var(--color-muted)] font-medium"
         >
           Keep going
         </button>
+
+        {/* Discard option */}
+        {!confirmDiscard ? (
+          <button
+            onClick={() => setConfirmDiscard(true)}
+            disabled={loading || discarding}
+            className="mt-2 w-full py-2 text-sm text-red-400 font-medium hover:text-red-500 transition-colors"
+          >
+            Discard workout
+          </button>
+        ) : (
+          <div className="relative z-20 mt-3 p-3 rounded-2xl border border-red-200 bg-red-50 space-y-2">
+            <div className="flex items-start gap-2 text-red-700">
+              <AlertTriangle size={15} className="mt-0.5 shrink-0" />
+              <p className="text-xs font-medium">
+                All logged sets will be permanently deleted. This cannot be undone.
+              </p>
+            </div>
+            <div className="flex gap-2">
+              <button
+                onClick={dismissDiscard}
+                className="flex-1 py-2 rounded-xl border border-[var(--color-border)] text-sm font-semibold text-[var(--color-muted)]"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleDiscard}
+                disabled={countdown > 0 || discarding}
+                className="flex-1 py-2 rounded-xl bg-red-500 text-white text-sm font-semibold disabled:opacity-40 transition-opacity duration-300"
+              >
+                {discarding ? 'Discarding…' : countdown > 0 ? `Yes, discard (${countdown})` : 'Yes, discard'}
+              </button>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/frontend/src/pages/ActiveWorkoutPage.tsx
+++ b/frontend/src/pages/ActiveWorkoutPage.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useParams, useLocation } from 'react-router-dom'
 import { Plus, Check, Clock, Dumbbell } from 'lucide-react'
 import { getExercises, type Exercise } from '../api/exercises'
 import { getLastSet, logSet, type LogEntry } from '../api/logs'
-import { endSession, clearActiveWorkout, getActiveWorkout, getSessionLogs, type SessionLogEntry } from '../api/workoutSessions'
+import { endSession, discardSession, clearActiveWorkout, getActiveWorkout, getSessionLogs, type SessionLogEntry } from '../api/workoutSessions'
 import FinishWorkoutSheet from '../components/FinishWorkoutSheet'
 
 interface SetRow {
@@ -199,6 +199,12 @@ export default function ActiveWorkoutPage() {
     }
   }
 
+  async function handleDiscard() {
+    await discardSession(id)
+    clearActiveWorkout()
+    navigate('/')
+  }
+
   return (
     <div className="pb-10">
 
@@ -389,6 +395,7 @@ export default function ActiveWorkoutPage() {
           exercises={exercises}
           sessionLogs={sessionLogs}
           onConfirm={handleConfirmFinish}
+          onDiscard={handleDiscard}
           onCancel={() => setShowSummary(false)}
           loading={finishing}
         />


### PR DESCRIPTION
The finish sheet could only be closed via the "Keep going" button. Tapping the backdrop had no effect, which felt unnatural on mobile.

Added onClick={onCancel} to the outer backdrop so tapping anywhere outside the sheet dismisses it. When the discard confirmation panel is open, the same tap dismisses the panel instead of the whole sheet, preserving the two-step discard safety flow.

Closes #193