### PR TITLE
feat: request ID middleware and structured logging (#173)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,10 +1,13 @@
+import logging
 import os
 import sys
+import uuid
 from contextlib import asynccontextmanager
 
 from dotenv import find_dotenv, load_dotenv
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware
 
 from database import SessionLocal
 from routers import admin as admin_router
@@ -21,6 +24,14 @@ from routers import stats as stats_router
 from seed import seed_exercises
 
 load_dotenv(find_dotenv())
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S",
+)
+
+logger = logging.getLogger(__name__)
 
 _REQUIRED = ["SECRET_KEY"]
 _missing = [v for v in _REQUIRED if not os.getenv(v)]
@@ -40,12 +51,22 @@ async def lifespan(app: FastAPI):
     yield
 
 
+class RequestIDMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        request_id = str(uuid.uuid4())
+        request.state.request_id = request_id
+        response = await call_next(request)
+        response.headers["X-Request-ID"] = request_id
+        return response
+
+
 app = FastAPI(title="Fitman API", lifespan=lifespan)
 
 origins = [
     o.strip() for o in os.getenv("CORS_ORIGINS", "http://localhost:3000").split(",")
 ]
 
+app.add_middleware(RequestIDMiddleware)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=origins,

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timezone
 
 import bcrypt
@@ -11,6 +12,8 @@ from models.cardio import CardioEntry
 from models.measurement import BodyMeasurement
 from models.user import User
 from models.workout import Log, WorkoutSession
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/admin", tags=["admin"])
 

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timezone
 from typing import Literal
 
@@ -9,6 +10,8 @@ from sqlalchemy.orm import Session
 from auth import create_access_token, get_current_user
 from database import get_db
 from models.user import User
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
 

--- a/backend/routers/cardio.py
+++ b/backend/routers/cardio.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -8,6 +9,8 @@ from auth import get_current_user
 from database import get_db
 from models.cardio import CardioEntry
 from models.user import User
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/cardio", tags=["cardio"])
 

--- a/backend/routers/gdpr.py
+++ b/backend/routers/gdpr.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, status
@@ -10,6 +11,8 @@ from models.cardio import CardioEntry
 from models.measurement import BodyMeasurement
 from models.user import User
 from models.workout import Log, WorkoutSession
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/gdpr", tags=["gdpr"])
 

--- a/backend/routers/logs.py
+++ b/backend/routers/logs.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -9,6 +10,8 @@ from database import get_db
 from models.exercise import Exercise
 from models.user import User
 from models.workout import Log, WorkoutSession
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/logs", tags=["logs"])
 

--- a/backend/routers/measurements.py
+++ b/backend/routers/measurements.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from datetime import datetime, timezone
 from typing import cast
@@ -11,6 +12,8 @@ from database import get_db
 from formulas import ImpedanceInputs, UserProfile, calculate_all
 from models.measurement import BodyMeasurement
 from models.user import User
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/measurements", tags=["measurements"])
 

--- a/backend/routers/profile.py
+++ b/backend/routers/profile.py
@@ -1,3 +1,5 @@
+import logging
+
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy.orm import Session
@@ -5,6 +7,8 @@ from sqlalchemy.orm import Session
 from auth import get_current_user
 from database import get_db
 from models.user import User
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/profile", tags=["profile"])
 

--- a/backend/routers/progress.py
+++ b/backend/routers/progress.py
@@ -1,3 +1,4 @@
+import logging
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 
@@ -10,6 +11,8 @@ from database import get_db
 from models.exercise import Exercise
 from models.user import User
 from models.workout import Log, WorkoutSession
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/progress", tags=["progress"])
 

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -11,6 +12,8 @@ from models.exercise import Exercise
 from models.user import User
 from models.workout import Log, WorkoutSession
 from routers.exercises import SESSIONS
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/sessions", tags=["sessions"])
 

--- a/backend/routers/stats.py
+++ b/backend/routers/stats.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import date, datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends
@@ -8,6 +9,8 @@ from auth import get_current_user
 from database import get_db
 from models.user import User
 from models.workout import Log, WorkoutSession
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/stats", tags=["stats"])
 

--- a/backend/tests/test_middleware.py
+++ b/backend/tests/test_middleware.py
@@ -1,0 +1,21 @@
+import uuid
+
+from fastapi.testclient import TestClient
+
+
+def test_request_id_header_present(client: TestClient):
+    response = client.get("/health")
+    assert "x-request-id" in response.headers
+
+
+def test_request_id_is_valid_uuid(client: TestClient):
+    response = client.get("/health")
+    request_id = response.headers["x-request-id"]
+    parsed = uuid.UUID(request_id)
+    assert parsed.version == 4
+
+
+def test_request_id_unique_per_request(client: TestClient):
+    r1 = client.get("/health")
+    r2 = client.get("/health")
+    assert r1.headers["x-request-id"] != r2.headers["x-request-id"]


### PR DESCRIPTION
The backend had zero logging — a production 500 gave no traceback, no user context, and no way to trace which request caused it.

Add a RequestIDMiddleware in main.py that generates a UUID4 per request and attaches it as an X-Request-ID response header. Configure logging.basicConfig with timestamp, level, logger name, and message. Add logging.getLogger(__name__) to every router module so log output is scoped by file.

Three tests in test_middleware.py verify the header is present, is a valid UUID4, and is unique across requests.

Closes #173