### PR TITLE
fix: /health returns 503 when database is unreachable (#174)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -5,11 +5,14 @@ import uuid
 from contextlib import asynccontextmanager
 
 from dotenv import find_dotenv, load_dotenv
-from fastapi import FastAPI, Request
+from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from sqlalchemy.orm import Session
+from sqlalchemy.sql import text
 from starlette.middleware.base import BaseHTTPMiddleware
 
-from database import SessionLocal
+from database import SessionLocal, get_db
 from routers import admin as admin_router
 from routers import auth as auth_router
 from routers import cardio as cardio_router
@@ -90,5 +93,13 @@ app.include_router(stats_router.router)
 
 
 @app.get("/health")
-def health():
-    return {"status": "ok"}
+def health(db: Session = Depends(get_db)):
+    try:
+        db.execute(text("SELECT 1"))
+        return {"status": "ok"}
+    except Exception:
+        logger.exception("Health check: database unavailable")
+        return JSONResponse(
+            status_code=503,
+            content={"status": "error", "detail": "database unavailable"},
+        )

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,29 @@
+from unittest.mock import MagicMock
+
+from fastapi.testclient import TestClient
+from sqlalchemy.exc import OperationalError
+
+from database import get_db
+from main import app
+
+
+def test_health_ok(client: TestClient):
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_health_db_down():
+    def mock_db_fail():
+        mock = MagicMock()
+        mock.execute.side_effect = OperationalError("DB down", None, None)
+        yield mock
+
+    app.dependency_overrides[get_db] = mock_db_fail
+    try:
+        with TestClient(app) as c:
+            response = c.get("/health")
+        assert response.status_code == 503
+        assert response.json()["status"] == "error"
+    finally:
+        app.dependency_overrides.pop(get_db, None)


### PR DESCRIPTION
The health endpoint returned {"status": "ok"} unconditionally, so Docker Compose would report the backend as healthy even when PostgreSQL was down, masking real failures from the container orchestrator.

Inject a DB session dependency and run SELECT 1 inside a try/except. Returns 200 {"status": "ok"} on success and 503 {"status": "error", "detail": "database unavailable"} on failure, with the exception logged via logger.exception for traceability.

Closes #174