### PR TITLE
feat: rate limiting on POST /api/auth/login (#175)

### DIFF
--- a/backend/limiter.py
+++ b/backend/limiter.py
@@ -1,0 +1,4 @@
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+limiter = Limiter(key_func=get_remote_address)

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,11 +8,14 @@ from dotenv import find_dotenv, load_dotenv
 from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import text
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from database import SessionLocal, get_db
+from limiter import limiter
 from routers import admin as admin_router
 from routers import auth as auth_router
 from routers import cardio as cardio_router
@@ -64,6 +67,8 @@ class RequestIDMiddleware(BaseHTTPMiddleware):
 
 
 app = FastAPI(title="Fitman API", lifespan=lifespan)
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)  # type: ignore[arg-type]
 
 origins = [
     o.strip() for o in os.getenv("CORS_ORIGINS", "http://localhost:3000").split(",")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,4 @@ PyJWT==2.13.0
 bcrypt==5.0.0
 python-dotenv==1.2.2
 psycopg2-binary==2.9.10
+slowapi==0.1.10

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -3,12 +3,13 @@ from datetime import datetime, timezone
 from typing import Literal
 
 import bcrypt
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from auth import create_access_token, get_current_user
 from database import get_db
+from limiter import limiter
 from models.user import User
 
 logger = logging.getLogger(__name__)
@@ -103,7 +104,8 @@ def change_password(
 
 
 @router.post("/login", response_model=TokenResponse)
-def login(body: LoginRequest, db: Session = Depends(get_db)):
+@limiter.limit("5/minute")
+def login(request: Request, body: LoginRequest, db: Session = Depends(get_db)):
     user = db.query(User).filter(User.username == body.username).first()
     if (
         not user

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -13,6 +13,7 @@ os.environ.setdefault(
 )
 
 from database import Base, SessionLocal, engine  # noqa: E402
+from limiter import limiter  # noqa: E402
 from main import app  # noqa: E402
 from models.user import User  # noqa: E402
 
@@ -32,6 +33,11 @@ _db.add(
 )
 _db.commit()
 _db.close()
+
+
+@pytest.fixture(autouse=True)
+def reset_rate_limits():
+    limiter.reset()
 
 
 @pytest.fixture(scope="session")

--- a/backend/tests/test_ratelimit.py
+++ b/backend/tests/test_ratelimit.py
@@ -1,0 +1,15 @@
+from fastapi.testclient import TestClient
+
+
+def test_login_rate_limit_triggers_on_sixth_attempt(client: TestClient):
+    payload = {"username": "nobody", "password": "wrongpass"}
+    for _ in range(5):
+        client.post("/api/auth/login", json=payload)
+    response = client.post("/api/auth/login", json=payload)
+    assert response.status_code == 429
+
+
+def test_rate_limit_does_not_affect_health_endpoint(client: TestClient):
+    for _ in range(10):
+        r = client.get("/health")
+        assert r.status_code == 200

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -33,11 +33,16 @@ def _auth_b(client: TestClient) -> dict:
     return {"Authorization": f"Bearer {token}"}
 
 
+_token_cache: dict[str, str] = {}
+
+
 def _token(client: TestClient) -> str:
-    resp = client.post(
-        "/api/auth/login", json={"username": "testuser", "password": "testpass"}
-    )
-    return resp.json()["access_token"]
+    if "testuser" not in _token_cache:
+        resp = client.post(
+            "/api/auth/login", json={"username": "testuser", "password": "testpass"}
+        )
+        _token_cache["testuser"] = resp.json()["access_token"]
+    return _token_cache["testuser"]
 
 
 def _auth(client: TestClient) -> dict:


### PR DESCRIPTION
The login endpoint had no rate limiting, allowing unlimited brute-force attempts from any device on the Tailscale network.

Add slowapi 0.1.10 with a shared Limiter instance (limiter.py) keyed on client IP. Apply a 5/minute limit to POST /api/auth/login via the @limiter.limit decorator; all other endpoints are unaffected. The limiter storage is reset before each test via an autouse fixture to prevent rate limit state leaking across tests.

Two tests in test_ratelimit.py verify the 6th attempt within a minute returns 429 and that /health remains unaffected after 10 requests.

Closes #175