### PR TITLE
feat: add HTTP security headers to nginx (#176)

### DIFF
--- a/backend/tests/test_nginx_conf.py
+++ b/backend/tests/test_nginx_conf.py
@@ -1,0 +1,29 @@
+"""Static checks that nginx.conf contains required HTTP security headers."""
+
+from pathlib import Path
+
+_CONF = Path(__file__).resolve().parents[2] / "frontend" / "nginx.conf"
+
+
+def _text() -> str:
+    return _CONF.read_text()
+
+
+def test_x_frame_options_header_present():
+    assert 'add_header X-Frame-Options "SAMEORIGIN"' in _text()
+
+
+def test_x_content_type_options_header_present():
+    assert 'add_header X-Content-Type-Options "nosniff"' in _text()
+
+
+def test_referrer_policy_header_present():
+    assert 'add_header Referrer-Policy "strict-origin-when-cross-origin"' in _text()
+
+
+def test_content_security_policy_header_present():
+    assert "add_header Content-Security-Policy" in _text()
+
+
+def test_permissions_policy_header_present():
+    assert "add_header Permissions-Policy" in _text()

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -5,6 +5,13 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+
     # index.html — never cache so browsers always load the latest entry point
     location = /index.html {
         try_files $uri =404;


### PR DESCRIPTION
nginx.conf served no security-related response headers, leaving the app exposed to clickjacking, MIME-type sniffing, and overly permissive resource loading.

Added five headers at the server block level so they apply to every response: X-Frame-Options (SAMEORIGIN), X-Content-Type-Options (nosniff), Referrer-Policy (strict-origin-when-cross-origin), a Content-Security-Policy restricted to self-origin resources with unsafe-inline styles for Tailwind, and Permissions-Policy disabling camera, microphone, and geolocation.

Five new static-analysis tests in test_nginx_conf.py parse the conf file directly — no nginx process required — so the assertions run in CI without extra infrastructure.

Closes #176