### PR TITLE
feat: add backend .dockerignore (#177)

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,13 @@
+.env
+.env.*
+.venv
+
+tests/
+__pycache__/
+*.pyc
+*.pyo
+
+requirements-dev.txt
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/

--- a/backend/tests/test_dockerignore.py
+++ b/backend/tests/test_dockerignore.py
@@ -1,0 +1,40 @@
+"""Static checks that backend/.dockerignore excludes security-sensitive and unnecessary paths."""
+
+from pathlib import Path
+
+_DOCKERIGNORE = Path(__file__).resolve().parents[1] / ".dockerignore"
+
+
+def _entries() -> set[str]:
+    return {
+        line.strip()
+        for line in _DOCKERIGNORE.read_text().splitlines()
+        if line.strip() and not line.startswith("#")
+    }
+
+
+def test_dockerignore_exists():
+    assert _DOCKERIGNORE.is_file()
+
+
+def test_env_file_excluded():
+    """Secrets must never be baked into the production image."""
+    assert ".env" in _entries()
+
+
+def test_venv_excluded():
+    """.venv would shadow the pip-installed packages inside the image."""
+    assert ".venv" in _entries()
+
+
+def test_tests_directory_excluded():
+    """Test code and fixtures have no place in a production image."""
+    assert "tests/" in _entries()
+
+
+def test_pycache_excluded():
+    assert "__pycache__/" in _entries()
+
+
+def test_dev_requirements_excluded():
+    assert "requirements-dev.txt" in _entries()


### PR DESCRIPTION
Without a .dockerignore the COPY . . in the Dockerfile baked the test suite, dev dependencies, virtual environment, .env secrets, and bytecode cache into the production image — bloating its size and risking credential leakage.

Added backend/.dockerignore excluding .env, .env.*, .venv, tests/, __pycache__/, *.pyc/pyo, requirements-dev.txt, and the three tool caches (.pytest_cache, .mypy_cache, .ruff_cache). The build context is ./backend so the file sits next to the Dockerfile where Docker expects it.

Six static-analysis tests in test_dockerignore.py parse the file directly and assert each critical exclusion is present.

Closes #177