### PR TITLE
M22 Security hardening

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,13 @@
+.env
+.env.*
+.venv
+
+tests/
+__pycache__/
+*.pyc
+*.pyo
+
+requirements-dev.txt
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/

--- a/backend/limiter.py
+++ b/backend/limiter.py
@@ -1,0 +1,4 @@
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+limiter = Limiter(key_func=get_remote_address)

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,11 +8,14 @@ from dotenv import find_dotenv, load_dotenv
 from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import text
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from database import SessionLocal, get_db
+from limiter import limiter
 from routers import admin as admin_router
 from routers import auth as auth_router
 from routers import cardio as cardio_router
@@ -64,6 +67,8 @@ class RequestIDMiddleware(BaseHTTPMiddleware):
 
 
 app = FastAPI(title="Fitman API", lifespan=lifespan)
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)  # type: ignore[arg-type]
 
 origins = [
     o.strip() for o in os.getenv("CORS_ORIGINS", "http://localhost:3000").split(",")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,4 @@ PyJWT==2.13.0
 bcrypt==5.0.0
 python-dotenv==1.2.2
 psycopg2-binary==2.9.10
+slowapi==0.1.10

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -3,12 +3,13 @@ from datetime import datetime, timezone
 from typing import Literal
 
 import bcrypt
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from auth import create_access_token, get_current_user
 from database import get_db
+from limiter import limiter
 from models.user import User
 
 logger = logging.getLogger(__name__)
@@ -103,7 +104,8 @@ def change_password(
 
 
 @router.post("/login", response_model=TokenResponse)
-def login(body: LoginRequest, db: Session = Depends(get_db)):
+@limiter.limit("5/minute")
+def login(request: Request, body: LoginRequest, db: Session = Depends(get_db)):
     user = db.query(User).filter(User.username == body.username).first()
     if (
         not user

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -13,6 +13,7 @@ os.environ.setdefault(
 )
 
 from database import Base, SessionLocal, engine  # noqa: E402
+from limiter import limiter  # noqa: E402
 from main import app  # noqa: E402
 from models.user import User  # noqa: E402
 
@@ -32,6 +33,11 @@ _db.add(
 )
 _db.commit()
 _db.close()
+
+
+@pytest.fixture(autouse=True)
+def reset_rate_limits():
+    limiter.reset()
 
 
 @pytest.fixture(scope="session")

--- a/backend/tests/test_dockerignore.py
+++ b/backend/tests/test_dockerignore.py
@@ -1,0 +1,40 @@
+"""Static checks that backend/.dockerignore excludes security-sensitive and unnecessary paths."""
+
+from pathlib import Path
+
+_DOCKERIGNORE = Path(__file__).resolve().parents[1] / ".dockerignore"
+
+
+def _entries() -> set[str]:
+    return {
+        line.strip()
+        for line in _DOCKERIGNORE.read_text().splitlines()
+        if line.strip() and not line.startswith("#")
+    }
+
+
+def test_dockerignore_exists():
+    assert _DOCKERIGNORE.is_file()
+
+
+def test_env_file_excluded():
+    """Secrets must never be baked into the production image."""
+    assert ".env" in _entries()
+
+
+def test_venv_excluded():
+    """.venv would shadow the pip-installed packages inside the image."""
+    assert ".venv" in _entries()
+
+
+def test_tests_directory_excluded():
+    """Test code and fixtures have no place in a production image."""
+    assert "tests/" in _entries()
+
+
+def test_pycache_excluded():
+    assert "__pycache__/" in _entries()
+
+
+def test_dev_requirements_excluded():
+    assert "requirements-dev.txt" in _entries()

--- a/backend/tests/test_nginx_conf.py
+++ b/backend/tests/test_nginx_conf.py
@@ -1,0 +1,29 @@
+"""Static checks that nginx.conf contains required HTTP security headers."""
+
+from pathlib import Path
+
+_CONF = Path(__file__).resolve().parents[2] / "frontend" / "nginx.conf"
+
+
+def _text() -> str:
+    return _CONF.read_text()
+
+
+def test_x_frame_options_header_present():
+    assert 'add_header X-Frame-Options "SAMEORIGIN"' in _text()
+
+
+def test_x_content_type_options_header_present():
+    assert 'add_header X-Content-Type-Options "nosniff"' in _text()
+
+
+def test_referrer_policy_header_present():
+    assert 'add_header Referrer-Policy "strict-origin-when-cross-origin"' in _text()
+
+
+def test_content_security_policy_header_present():
+    assert "add_header Content-Security-Policy" in _text()
+
+
+def test_permissions_policy_header_present():
+    assert "add_header Permissions-Policy" in _text()

--- a/backend/tests/test_ratelimit.py
+++ b/backend/tests/test_ratelimit.py
@@ -1,0 +1,15 @@
+from fastapi.testclient import TestClient
+
+
+def test_login_rate_limit_triggers_on_sixth_attempt(client: TestClient):
+    payload = {"username": "nobody", "password": "wrongpass"}
+    for _ in range(5):
+        client.post("/api/auth/login", json=payload)
+    response = client.post("/api/auth/login", json=payload)
+    assert response.status_code == 429
+
+
+def test_rate_limit_does_not_affect_health_endpoint(client: TestClient):
+    for _ in range(10):
+        r = client.get("/health")
+        assert r.status_code == 200

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -33,11 +33,16 @@ def _auth_b(client: TestClient) -> dict:
     return {"Authorization": f"Bearer {token}"}
 
 
+_token_cache: dict[str, str] = {}
+
+
 def _token(client: TestClient) -> str:
-    resp = client.post(
-        "/api/auth/login", json={"username": "testuser", "password": "testpass"}
-    )
-    return resp.json()["access_token"]
+    if "testuser" not in _token_cache:
+        resp = client.post(
+            "/api/auth/login", json={"username": "testuser", "password": "testpass"}
+        )
+        _token_cache["testuser"] = resp.json()["access_token"]
+    return _token_cache["testuser"]
 
 
 def _auth(client: TestClient) -> dict:

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -5,6 +5,13 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+
     # index.html — never cache so browsers always load the latest entry point
     location = /index.html {
         try_files $uri =404;


### PR DESCRIPTION
Three security issues closed in this milestone.

Issue #175 — Login rate limiting: SlowAPI wired into FastAPI; the
/api/auth/login endpoint is limited to 5 requests per minute per IP.
A shared limiter.py singleton keeps the decorator and the exception
handler on the same instance. An autouse fixture resets in-memory
counters before every test to prevent state leaking across the suite.

Issue #176 — nginx security headers: Five add_header directives added
at the server block level in frontend/nginx.conf, covering
X-Frame-Options, X-Content-Type-Options, Referrer-Policy,
Content-Security-Policy, and Permissions-Policy. All responses —
static assets and proxied API calls — carry these headers.

Issue #177 — Backend .dockerignore: Without this file, COPY . . in
the Dockerfile baked secrets (.env), the virtual environment, the
test suite, and dev dependencies into the production image. The new
backend/.dockerignore excludes all of them.

11 new tests added (188 total). Ruff and mypy clean.

Closes #175
Closes #176
Closes #177
