### PR TITLE
Fix/178 consistency n plus one

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -30,6 +30,7 @@ Fitman is a two-service web application: a Python REST API and a React single-pa
 - Reads and writes all data to PostgreSQL via SQLAlchemy
 - Runs database migrations automatically on startup via Alembic
 - Attaches a `X-Request-ID` UUID header to every response for log tracing
+- Rate-limits the login endpoint to 5 requests per minute per IP (SlowAPI)
 - Runs on port `8000` inside Docker (internal only — not exposed to the host)
 
 ### Frontend — React + TypeScript
@@ -38,6 +39,7 @@ Fitman is a two-service web application: a Python REST API and a React single-pa
 - Communicates with the backend via nginx proxy (no direct connection to port 8000)
 - Tailwind CSS v4 for styling
 - In production: built to static files and served by nginx
+- nginx adds five HTTP security headers on every response: `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Content-Security-Policy`, and `Permissions-Policy`
 - In development: Vite dev server on port `5173` with `/api` proxy to backend
 
 ### Database — PostgreSQL 16
@@ -78,6 +80,7 @@ Fitman/
 │   │   └── versions/        # One file per schema change
 │   ├── alembic.ini
 │   ├── Dockerfile
+│   ├── .dockerignore        # Excludes .env, .venv, tests/, __pycache__, dev deps from image
 │   ├── requirements.txt
 │   ├── requirements-dev.txt # Dev/CI dependencies (pytest, ruff, mypy)
 │   ├── pyproject.toml       # Ruff and mypy configuration

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fitman
 
-[![CI](https://github.com/Dave-Nijhuis/Fitman/actions/workflows/ci.yml/badge.svg)](https://github.com/Dave-Nijhuis/Fitman/actions/workflows/ci.yml)
+[![CI](https://github.com/DaveNijhuis/Fitman/actions/workflows/ci.yml/badge.svg)](https://github.com/DaveNijhuis/Fitman/actions/workflows/ci.yml)
 [![Python](https://img.shields.io/badge/python-3.11+-blue?logo=python&logoColor=white)](https://www.python.org/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-009688?logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com/)
 [![React](https://img.shields.io/badge/React-18-61DAFB?logo=react&logoColor=black)](https://react.dev/)
@@ -9,7 +9,7 @@
 [![Docker](https://img.shields.io/badge/Docker-ready-2496ED?logo=docker&logoColor=white)](https://www.docker.com/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-175%20passing-brightgreen)](TESTING.md)
+[![Tests](https://img.shields.io/badge/tests-188%20passing-brightgreen)](TESTING.md)
 
 A self-hosted fitness tracking app. Log workouts, track progress, own your data.
 
@@ -67,7 +67,7 @@ In the [Tailscale admin console](https://login.tailscale.com/admin/machines), re
 
 ```bash
 # Clone the repo on your server
-git clone https://github.com/Dave-Nijhuis/Fitman.git
+git clone https://github.com/DaveNijhuis/Fitman.git
 cd Fitman
 
 # Set up environment variables
@@ -219,7 +219,7 @@ All work flows through feature branches → `dev` → `main` via pull request.
 
 ## Project board
 
-Issues and feature tracking are managed in the [GitHub Project](https://github.com/users/Dave-Nijhuis/projects/3).
+Issues and feature tracking are managed in the [GitHub Project](https://github.com/users/DaveNijhuis/projects/3).
 
 ## Built with AI
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -64,6 +64,9 @@ All tests live in `backend/tests/`. The suite runs against a real PostgreSQL dat
 | `test_postgresql.py` | PostgreSQL migration structural tests: engine dialect is postgresql, no TZDateTime custom type in any model |
 | `test_middleware.py` | Request ID middleware: `X-Request-ID` header present on all responses, value is a valid UUID4, unique per request |
 | `test_health.py` | `GET /health` returns 200 under normal conditions; returns 503 with `{"status": "error"}` when the database is unreachable (tested via dependency override) |
+| `test_ratelimit.py` | Login rate limiting: 6th request within a minute returns 429; health endpoint is not rate-limited |
+| `test_nginx_conf.py` | Static parse of `frontend/nginx.conf`: asserts all five security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Content-Security-Policy`, `Permissions-Policy`) are present |
+| `test_dockerignore.py` | Static parse of `backend/.dockerignore`: asserts `.env`, `.venv`, `tests/`, `__pycache__/`, and `requirements-dev.txt` are excluded from the Docker build context |
 
 ## conftest.py
 
@@ -73,6 +76,8 @@ A single `session`-scoped `TestClient` is shared across all tests. The database 
 - The full exercise library (via `seed.py`)
 
 Because the database is shared across tests, individual tests must not rely on the database being empty. Tests that need specific data insert it directly via `SessionLocal`.
+
+An `autouse=True` function-scoped fixture calls `limiter.reset()` before every test, clearing the in-memory rate limit counters so tests do not leak state across each other.
 
 `DATABASE_URL` must be set in the environment before the test session starts. `conftest.py` defaults to `postgresql://fitman:fitman@localhost:5432/fitman_test` if the variable is not set.
 

--- a/backend/routers/progress.py
+++ b/backend/routers/progress.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from auth import get_current_user
@@ -120,21 +121,24 @@ def consistency(
     current_user: User = Depends(get_current_user),
 ):
     cutoff = datetime.now(timezone.utc) - timedelta(weeks=17)
-    sessions = (
-        db.query(WorkoutSession)
+    rows = (
+        db.query(
+            WorkoutSession,
+            func.coalesce(func.sum(Log.weight * Log.reps), 0).label("volume"),
+        )
+        .outerjoin(Log, Log.session_id == WorkoutSession.id)
         .filter(
             WorkoutSession.user_id == current_user.id,
             WorkoutSession.started_at >= cutoff,
             WorkoutSession.ended_at.isnot(None),
         )
+        .group_by(WorkoutSession.id)
         .all()
     )
 
     trained_data: dict[str, dict] = {}
-    for s in sessions:
+    for s, volume in rows:
         date = s.started_at.date().isoformat()
-        logs = db.query(Log).filter(Log.session_id == s.id).all()
-        volume = sum(log.weight * log.reps for log in logs)
         trained_data[date] = {"session": s.session, "volume_kg": round(volume, 1)}
 
     now = datetime.now(timezone.utc)

--- a/backend/tests/test_progress.py
+++ b/backend/tests/test_progress.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from fastapi.testclient import TestClient
 
@@ -300,6 +300,65 @@ def test_prs_picks_best_set_per_exercise(client: TestClient):
     assert match["estimated_1rm"] >= 100.0
     assert "exercise_name" in match
     assert "date" in match
+
+
+# ── N+1 regression (#178) ────────────────────────────────────────────────────
+
+
+def test_consistency_single_query(client: TestClient):
+    """GET /api/progress/consistency must not fire one query per session (N+1).
+
+    Seeds 5 completed sessions with logs directly in the DB, then counts
+    SELECT statements during the consistency request. The current implementation
+    fires 1 (sessions fetch) + 5 (one logs query per session) = 6 queries.
+    The fix aggregates volume in SQL so the total must be ≤2 (auth + one query).
+    """
+    from sqlalchemy import event
+
+    from database import SessionLocal, engine
+
+    db = SessionLocal()
+    ex = db.query(Exercise).filter(Exercise.session == "Push A").first()
+    assert ex is not None
+    exercise_id = ex.id
+    now = datetime.now(timezone.utc)
+    for i in range(5):
+        s = WorkoutSession(
+            user_id=1,
+            session="Push A",
+            started_at=now - timedelta(days=i + 2),
+            ended_at=now - timedelta(days=i + 1),
+        )
+        db.add(s)
+        db.flush()
+        db.add(
+            Log(
+                session_id=s.id,
+                exercise_id=exercise_id,
+                weight=50.0,
+                reps=8,
+                logged_at=now - timedelta(days=i + 2),
+            )
+        )
+    db.commit()
+    db.close()
+
+    headers = _auth(client)
+    query_count = 0
+
+    def _count(conn, cursor, statement, parameters, context, executemany):
+        nonlocal query_count
+        if statement.strip().upper().startswith("SELECT"):
+            query_count += 1
+
+    event.listen(engine, "before_cursor_execute", _count)
+    try:
+        resp = client.get("/api/progress/consistency", headers=headers)
+    finally:
+        event.remove(engine, "before_cursor_execute", _count)
+
+    assert resp.status_code == 200
+    assert query_count <= 2, f"N+1 detected: {query_count} SELECT queries (expected ≤2)"
 
 
 # ── N+1 regression (#130) ─────────────────────────────────────────────────────


### PR DESCRIPTION
fix: eliminate N+1 query in GET /api/progress/consistency (#178)

The consistency endpoint fetched sessions in one query, then issued a
separate SELECT per session to sum log volume — O(N) queries for N
sessions in the 17-week window.

Replaced the per-session loop with a single outerjoin aggregation
(func.sum(Log.weight * Log.reps) grouped by WorkoutSession.id) so
the entire handler runs in one SQL round-trip regardless of session
count.

Added test_consistency_single_query to test_progress.py — seeds 5
sessions directly via the DB and asserts the consistency endpoint
issues ≤2 SELECT statements (auth + one aggregated join).

Closes #178
