### PR TITLE
refactor: move hash_password and verify_password to auth.py (#180)

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -2,6 +2,7 @@ import os
 from datetime import datetime, timedelta, timezone
 from typing import Annotated
 
+import bcrypt
 import jwt
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -11,6 +12,15 @@ from database import get_db
 from models.user import User
 
 ALGORITHM = "HS256"
+
+
+def hash_password(plain: str) -> str:
+    return bcrypt.hashpw(plain.encode(), bcrypt.gensalt()).decode()
+
+
+def verify_password(plain: str, hashed: str) -> bool:
+    return bcrypt.checkpw(plain.encode(), hashed.encode())
+
 
 bearer = HTTPBearer()
 

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1,12 +1,11 @@
 import logging
 from datetime import datetime, timezone
 
-import bcrypt
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.orm import Session
 
-from auth import get_current_user
+from auth import get_current_user, hash_password
 from database import get_db
 from models.cardio import CardioEntry
 from models.measurement import BodyMeasurement
@@ -24,10 +23,6 @@ def _require_admin(current_user: User = Depends(get_current_user)) -> User:
             status_code=status.HTTP_403_FORBIDDEN, detail="Admin access required"
         )
     return current_user
-
-
-def _hash_password(plain: str) -> str:
-    return bcrypt.hashpw(plain.encode(), bcrypt.gensalt()).decode()
 
 
 class UserOut(BaseModel):
@@ -75,7 +70,7 @@ def create_user(
         )
     user = User(
         username=body.username,
-        hashed_password=_hash_password(body.password),
+        hashed_password=hash_password(body.password),
         email=body.email,
         display_name=body.display_name,
         is_active=True,

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -2,12 +2,11 @@ import logging
 from datetime import datetime, timezone
 from typing import Literal
 
-import bcrypt
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
-from auth import create_access_token, get_current_user
+from auth import create_access_token, get_current_user, hash_password, verify_password
 from database import get_db
 from limiter import limiter
 from models.user import User
@@ -15,14 +14,6 @@ from models.user import User
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
-
-
-def _hash_password(plain: str) -> str:
-    return bcrypt.hashpw(plain.encode(), bcrypt.gensalt()).decode()
-
-
-def _verify_password(plain: str, hashed: str) -> bool:
-    return bcrypt.checkpw(plain.encode(), hashed.encode())
 
 
 class LoginRequest(BaseModel):
@@ -69,7 +60,7 @@ def register(body: RegisterRequest, db: Session = Depends(get_db)):
 
     user = User(
         username=body.username,
-        hashed_password=_hash_password(body.password),
+        hashed_password=hash_password(body.password),
         display_name=body.display_name,
         is_active=True,
         is_admin=True,  # first user is always admin
@@ -93,12 +84,12 @@ def change_password(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    if not _verify_password(body.current_password, current_user.hashed_password):
+    if not verify_password(body.current_password, current_user.hashed_password):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Current password is incorrect",
         )
-    current_user.hashed_password = _hash_password(body.new_password)
+    current_user.hashed_password = hash_password(body.new_password)
     db.commit()
     return {"detail": "Password updated"}
 
@@ -110,7 +101,7 @@ def login(request: Request, body: LoginRequest, db: Session = Depends(get_db)):
     if (
         not user
         or not user.is_active
-        or not _verify_password(body.password, user.hashed_password)
+        or not verify_password(body.password, user.hashed_password)
     ):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials"

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -3,9 +3,9 @@ from datetime import datetime, timezone
 import bcrypt
 from fastapi.testclient import TestClient
 
+from auth import verify_password as _verify_password
 from database import SessionLocal
 from models.user import User
-from routers.auth import _verify_password
 
 # ── Unit tests ────────────────────────────────────────────────────────────────
 

--- a/backend/tests/test_hash_password_dedup.py
+++ b/backend/tests/test_hash_password_dedup.py
@@ -1,0 +1,57 @@
+"""Verify _hash_password is defined once in auth.py, not duplicated in routers."""
+
+import inspect
+
+import routers.admin as admin_module
+import routers.auth as auth_router_module
+
+
+def test_hash_password_lives_in_auth():
+    """auth.hash_password must be importable and produce a valid bcrypt hash."""
+    from auth import hash_password, verify_password
+
+    hashed = hash_password("secret123")
+    assert hashed != "secret123"
+    assert hashed.startswith("$2b$")
+    assert verify_password("secret123", hashed)
+    assert not verify_password("wrong", hashed)
+
+
+def test_auth_router_does_not_define_hash_password():
+    """routers/auth.py must not define its own _hash_password."""
+    assert not hasattr(auth_router_module, "_hash_password"), (
+        "routers/auth.py still defines _hash_password — remove it and import from auth"
+    )
+
+
+def test_admin_does_not_define_hash_password():
+    """routers/admin.py must not define its own _hash_password."""
+    assert not hasattr(admin_module, "_hash_password"), (
+        "routers/admin.py still defines _hash_password — remove it and import from auth"
+    )
+
+
+def test_routers_share_same_hash_function():
+    """Both routers must use the same hash_password from auth, not separate copies."""
+    from auth import hash_password
+
+    # Both modules must reference the canonical function from auth
+    auth_router_fn = getattr(auth_router_module, "hash_password", None)
+    admin_fn = getattr(admin_module, "hash_password", None)
+
+    assert auth_router_fn is hash_password, (
+        "routers/auth.py does not import hash_password from auth"
+    )
+    assert admin_fn is hash_password, (
+        "routers/admin.py does not import hash_password from auth"
+    )
+
+
+def test_hash_password_source_is_auth_module():
+    """hash_password must be defined in auth.py, not in any router."""
+    from auth import hash_password
+
+    source_file = inspect.getfile(hash_password)
+    assert source_file.endswith("auth.py") and "routers" not in source_file, (
+        f"hash_password is defined in {source_file}, expected backend/auth.py"
+    )


### PR DESCRIPTION
The bcrypt helper _hash_password was defined identically in both routers/auth.py and routers/admin.py, and _verify_password lived only in routers/auth.py. Any password-hashing logic belongs in the auth module, not scattered across routers.

Moved both functions to auth.py as public hash_password and verify_password, removed the private copies from both routers, and updated all call sites to import from auth. Added
test_hash_password_dedup.py with 5 tests: importability, absence of private copies in each router, identity check that both routers reference the same function object, and source-file verification.

Closes #180