### PR TITLE
fix: validate sex and birth_year on PATCH /api/profile (#181)

### DIFF
--- a/backend/routers/profile.py
+++ b/backend/routers/profile.py
@@ -1,7 +1,9 @@
 import logging
+from datetime import datetime, timezone
+from typing import Literal
 
 from fastapi import APIRouter, Depends
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 from sqlalchemy.orm import Session
 
 from auth import get_current_user
@@ -28,8 +30,18 @@ class ProfileOut(BaseModel):
 class ProfilePatch(BaseModel):
     display_name: str | None = None
     birth_year: int | None = None
-    sex: str | None = None
+    sex: Literal["male", "female", "other"] | None = None
     height_cm: float | None = None
+
+    @field_validator("birth_year")
+    @classmethod
+    def birth_year_in_range(cls, v: int | None) -> int | None:
+        if v is None:
+            return v
+        current_year = datetime.now(timezone.utc).year
+        if not (1900 <= v <= current_year):
+            raise ValueError(f"birth_year must be between 1900 and {current_year}")
+        return v
 
 
 @router.get("", response_model=ProfileOut)

--- a/backend/tests/test_profile.py
+++ b/backend/tests/test_profile.py
@@ -71,6 +71,70 @@ def test_patch_profile_ignores_unknown_fields(client: TestClient):
     assert resp.status_code == 200
 
 
+# ── Input validation (#181) ───────────────────────────────────────────────────
+
+
+def test_patch_sex_invalid_value_returns_422(client: TestClient):
+    resp = client.patch("/api/profile", json={"sex": "banana"}, headers=_auth(client))
+    assert resp.status_code == 422
+
+
+def test_patch_sex_empty_string_returns_422(client: TestClient):
+    resp = client.patch("/api/profile", json={"sex": ""}, headers=_auth(client))
+    assert resp.status_code == 422
+
+
+def test_patch_sex_accepts_all_valid_values(client: TestClient):
+    headers = _auth(client)
+    for value in ("male", "female", "other"):
+        resp = client.patch("/api/profile", json={"sex": value}, headers=headers)
+        assert resp.status_code == 200, (
+            f"Expected 200 for sex={value!r}, got {resp.status_code}"
+        )
+        assert resp.json()["sex"] == value
+
+
+def test_patch_birth_year_below_minimum_returns_422(client: TestClient):
+    resp = client.patch(
+        "/api/profile", json={"birth_year": 1899}, headers=_auth(client)
+    )
+    assert resp.status_code == 422
+
+
+def test_patch_birth_year_negative_returns_422(client: TestClient):
+    resp = client.patch("/api/profile", json={"birth_year": -1}, headers=_auth(client))
+    assert resp.status_code == 422
+
+
+def test_patch_birth_year_future_returns_422(client: TestClient):
+    from datetime import datetime
+
+    future_year = datetime.now().year + 1
+    resp = client.patch(
+        "/api/profile", json={"birth_year": future_year}, headers=_auth(client)
+    )
+    assert resp.status_code == 422
+
+
+def test_patch_birth_year_minimum_boundary_valid(client: TestClient):
+    resp = client.patch(
+        "/api/profile", json={"birth_year": 1900}, headers=_auth(client)
+    )
+    assert resp.status_code == 200
+    assert resp.json()["birth_year"] == 1900
+
+
+def test_patch_birth_year_current_year_valid(client: TestClient):
+    from datetime import datetime
+
+    current_year = datetime.now().year
+    resp = client.patch(
+        "/api/profile", json={"birth_year": current_year}, headers=_auth(client)
+    )
+    assert resp.status_code == 200
+    assert resp.json()["birth_year"] == current_year
+
+
 # ── Profile fields used as BIA fallback ───────────────────────────────────────
 
 


### PR DESCRIPTION
ProfilePatch accepted any string for sex and any integer for birth_year, silently persisting values like "banana" or -5 to the database.

Constrained sex to Literal["male", "female", "other"] and added a field_validator for birth_year that rejects values outside 1900–current_year. Both violations return 422. Added 8 tests covering invalid values, empty string, all three valid sex values, and the 1900/current-year boundaries.

Closes #181