### PR TITLE
test: verify expired JWT tokens are rejected with 401 (#182)

### DIFF
--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,8 +1,11 @@
-from datetime import datetime, timezone
+import os
+from datetime import datetime, timedelta, timezone
 
 import bcrypt
+import jwt
 from fastapi.testclient import TestClient
 
+from auth import ALGORITHM
 from auth import verify_password as _verify_password
 from database import SessionLocal
 from models.user import User
@@ -246,3 +249,36 @@ def test_consent_given_at_column_exists(client: TestClient):
     assert user is not None
     assert hasattr(user, "consent_given_at")
     db.close()
+
+
+# ── Expired JWT (#182) ────────────────────────────────────────────────────────
+
+
+def _expired_token(user_id: int) -> str:
+    expired = datetime.now(timezone.utc) - timedelta(seconds=1)
+    return jwt.encode(
+        {"sub": str(user_id), "exp": expired},
+        os.getenv("SECRET_KEY"),
+        algorithm=ALGORITHM,
+    )
+
+
+def test_expired_token_returns_401(client: TestClient):
+    token = _expired_token(1)
+    resp = client.get("/api/profile", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401
+
+
+def test_expired_token_detail_is_invalid_token(client: TestClient):
+    """Response body must say 'Invalid token', not leak expiry details."""
+    token = _expired_token(1)
+    resp = client.get("/api/profile", headers={"Authorization": f"Bearer {token}"})
+    assert resp.json()["detail"] == "Invalid token"
+
+
+def test_expired_token_rejected_on_any_protected_endpoint(client: TestClient):
+    """Expiry check applies to all protected routes, not just /api/profile."""
+    token = _expired_token(1)
+    headers = {"Authorization": f"Bearer {token}"}
+    assert client.get("/api/exercises", headers=headers).status_code == 401
+    assert client.get("/api/stats/home", headers=headers).status_code == 401


### PR DESCRIPTION
No test existed to confirm that get_current_user rejects tokens whose exp claim is in the past. The implementation already caught ExpiredSignatureError via the jwt.InvalidTokenError handler, but a regression could go undetected without explicit coverage.

Added three tests in test_auth.py: expired token returns 401, response detail is the generic "Invalid token" (no expiry information leaked), and the check applies across multiple protected endpoints.

Closes #182