### PR TITLE
fix: correct activity casing in GDPR test fixture (#183)

### DIFF
--- a/backend/tests/test_gdpr.py
+++ b/backend/tests/test_gdpr.py
@@ -57,7 +57,7 @@ def _seed_data(user_id: int) -> None:
     db.add(
         CardioEntry(
             user_id=user_id,
-            activity="run",
+            activity="Run",
             duration_s=1800,
             logged_at=datetime.now(timezone.utc),
         )
@@ -195,3 +195,28 @@ def test_export_includes_workout_sessions(client: TestClient):
     data = client.get("/api/gdpr/export", headers=headers).json()
     assert isinstance(data["workout_sessions"], list)
     assert any(s["id"] == session["id"] for s in data["workout_sessions"])
+
+
+# ── Fixture data integrity (#183) ─────────────────────────────────────────────
+
+
+def test_seed_data_cardio_activity_is_valid(client: TestClient):
+    """_seed_data must seed a valid title-case activity, not a raw lowercase string.
+
+    CardioEntry is inserted directly into the DB so the API validation in
+    POST /api/cardio is bypassed. If the activity value is wrong it silently
+    persists and pollutes GDPR exports with invalid data.
+    """
+    from routers.cardio import ACTIVITIES
+
+    user_id = _make_user("seed_activity_check")
+    _seed_data(user_id)
+
+    db = SessionLocal()
+    entry = db.query(CardioEntry).filter(CardioEntry.user_id == user_id).first()
+    db.close()
+
+    assert entry is not None
+    assert entry.activity in ACTIVITIES, (
+        f"Seeded activity {entry.activity!r} is not a valid value; expected one of {ACTIVITIES}"
+    )


### PR DESCRIPTION
_seed_data in test_gdpr.py seeded CardioEntry with activity="run" (lowercase). The valid values defined in ACTIVITIES are all title-case ("Run", "Walk", etc.). Because the fixture inserts directly into the DB it bypassed the API validation, silently storing an invalid value that would appear in GDPR exports.

Changed "run" to "Run" and added test_seed_data_cardio_activity_is_valid which reads the seeded entry back from the DB and asserts its activity is in the ACTIVITIES list, preventing the same regression.

Closes #183