### PR TITLE
fix: add ON DELETE CASCADE to user_id FK constraints (#184)

### DIFF
--- a/backend/alembic/versions/g3h5i7j9k1l2_add_fk_cascade_on_user_id.py
+++ b/backend/alembic/versions/g3h5i7j9k1l2_add_fk_cascade_on_user_id.py
@@ -1,0 +1,66 @@
+"""add ON DELETE CASCADE to user_id FK constraints
+
+Revision ID: g3h5i7j9k1l2
+Revises: f1a2b3c4d5e6
+Create Date: 2026-07-12
+
+Migration b3d7f9e1c4a2 added user_id columns to workout_sessions,
+cardio_entries, and body_measurements as plain integers with no FK
+constraint. This migration adds the FK references to users.id with
+ON DELETE CASCADE so that deleting a user at the DB level automatically
+removes all their data, matching the application-level cascade in the
+admin delete endpoint.
+
+If a FK without CASCADE already exists (e.g. from an environment where
+create_all was run against an older model), it is dropped and recreated.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "g3h5i7j9k1l2"
+down_revision: Union[str, None] = "f1a2b3c4d5e6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_TABLES = ["workout_sessions", "cardio_entries", "body_measurements"]
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    for table in _TABLES:
+        existing = {fk["name"] for fk in inspector.get_foreign_keys(table)}
+        fk_name = f"{table}_user_id_fkey"
+        if fk_name in existing:
+            op.drop_constraint(fk_name, table, type_="foreignkey")
+        op.create_foreign_key(
+            fk_name,
+            table,
+            "users",
+            ["user_id"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    for table in _TABLES:
+        existing = {fk["name"] for fk in inspector.get_foreign_keys(table)}
+        fk_name = f"{table}_user_id_fkey"
+        if fk_name in existing:
+            op.drop_constraint(fk_name, table, type_="foreignkey")
+        # Restore FK without CASCADE
+        op.create_foreign_key(
+            fk_name,
+            table,
+            "users",
+            ["user_id"],
+            ["id"],
+        )

--- a/backend/models/cardio.py
+++ b/backend/models/cardio.py
@@ -11,7 +11,7 @@ class CardioEntry(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     user_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("users.id"), nullable=False, index=True
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
     )
     activity: Mapped[str] = mapped_column(String, nullable=False)
     distance_m: Mapped[float | None] = mapped_column(Float)

--- a/backend/models/measurement.py
+++ b/backend/models/measurement.py
@@ -11,7 +11,7 @@ class BodyMeasurement(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     user_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("users.id"), nullable=False, index=True
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
     )
     recorded_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False

--- a/backend/models/workout.py
+++ b/backend/models/workout.py
@@ -11,7 +11,7 @@ class WorkoutSession(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     user_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("users.id"), nullable=False, index=True
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
     )
     session: Mapped[str] = mapped_column(String, nullable=False)
     started_at: Mapped[datetime] = mapped_column(

--- a/backend/tests/test_fk_cascade.py
+++ b/backend/tests/test_fk_cascade.py
@@ -1,0 +1,144 @@
+"""FK constraint + ON DELETE CASCADE tests (#184).
+
+The test DB is built via Base.metadata.create_all so FK declarations on the
+models are what drive these tests. The Alembic migration must also be updated
+for production, but correctness is proved here at the model level.
+"""
+
+from datetime import datetime, timezone
+
+import bcrypt
+from sqlalchemy import inspect, text
+
+from database import SessionLocal, engine
+from models.cardio import CardioEntry
+from models.measurement import BodyMeasurement
+from models.user import User
+from models.workout import WorkoutSession
+
+
+def _user_id_fk(table: str) -> dict | None:
+    for fk in inspect(engine).get_foreign_keys(table):
+        if "user_id" in fk["constrained_columns"]:
+            return fk
+    return None
+
+
+# ── FK constraint exists ───────────────────────────────────────────────────────
+
+
+def test_workout_sessions_user_id_fk_exists():
+    assert _user_id_fk("workout_sessions") is not None
+
+
+def test_cardio_entries_user_id_fk_exists():
+    assert _user_id_fk("cardio_entries") is not None
+
+
+def test_body_measurements_user_id_fk_exists():
+    assert _user_id_fk("body_measurements") is not None
+
+
+# ── ON DELETE CASCADE ─────────────────────────────────────────────────────────
+
+
+def test_workout_sessions_user_id_fk_has_cascade_delete():
+    fk = _user_id_fk("workout_sessions")
+    assert fk is not None
+    assert fk.get("options", {}).get("ondelete", "").upper() == "CASCADE", (
+        f"workout_sessions.user_id FK missing ON DELETE CASCADE; options={fk.get('options')}"
+    )
+
+
+def test_cardio_entries_user_id_fk_has_cascade_delete():
+    fk = _user_id_fk("cardio_entries")
+    assert fk is not None
+    assert fk.get("options", {}).get("ondelete", "").upper() == "CASCADE", (
+        f"cardio_entries.user_id FK missing ON DELETE CASCADE; options={fk.get('options')}"
+    )
+
+
+def test_body_measurements_user_id_fk_has_cascade_delete():
+    fk = _user_id_fk("body_measurements")
+    assert fk is not None
+    assert fk.get("options", {}).get("ondelete", "").upper() == "CASCADE", (
+        f"body_measurements.user_id FK missing ON DELETE CASCADE; options={fk.get('options')}"
+    )
+
+
+# ── Behavioural: raw delete cascades to child rows ────────────────────────────
+
+
+def _make_user_with_data() -> int:
+    db = SessionLocal()
+    user = User(
+        username=f"cascade_test_{datetime.now(timezone.utc).timestamp()}",
+        hashed_password=bcrypt.hashpw(b"pass1234", bcrypt.gensalt(rounds=4)).decode(),
+        is_active=True,
+        is_admin=False,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    user_id = user.id
+
+    db.add(
+        WorkoutSession(
+            user_id=user_id,
+            session="Push A",
+            started_at=datetime.now(timezone.utc),
+            ended_at=datetime.now(timezone.utc),
+        )
+    )
+    db.add(
+        CardioEntry(
+            user_id=user_id,
+            activity="Run",
+            duration_s=600,
+            logged_at=datetime.now(timezone.utc),
+        )
+    )
+    db.add(
+        BodyMeasurement(
+            user_id=user_id,
+            weight_kg=75.0,
+            recorded_at=datetime.now(timezone.utc),
+        )
+    )
+    db.commit()
+    db.close()
+    return user_id
+
+
+def test_raw_user_delete_cascades_workout_sessions():
+    user_id = _make_user_with_data()
+    with engine.connect() as conn:
+        conn.execute(text("DELETE FROM users WHERE id = :uid"), {"uid": user_id})
+        conn.commit()
+    db = SessionLocal()
+    count = db.query(WorkoutSession).filter(WorkoutSession.user_id == user_id).count()
+    db.close()
+    assert count == 0, f"Expected 0 workout_sessions after user delete, got {count}"
+
+
+def test_raw_user_delete_cascades_cardio_entries():
+    user_id = _make_user_with_data()
+    with engine.connect() as conn:
+        conn.execute(text("DELETE FROM users WHERE id = :uid"), {"uid": user_id})
+        conn.commit()
+    db = SessionLocal()
+    count = db.query(CardioEntry).filter(CardioEntry.user_id == user_id).count()
+    db.close()
+    assert count == 0, f"Expected 0 cardio_entries after user delete, got {count}"
+
+
+def test_raw_user_delete_cascades_body_measurements():
+    user_id = _make_user_with_data()
+    with engine.connect() as conn:
+        conn.execute(text("DELETE FROM users WHERE id = :uid"), {"uid": user_id})
+        conn.commit()
+    db = SessionLocal()
+    count = db.query(BodyMeasurement).filter(BodyMeasurement.user_id == user_id).count()
+    db.close()
+    assert count == 0, f"Expected 0 body_measurements after user delete, got {count}"


### PR DESCRIPTION
Migration b3d7f9e1c4a2 added user_id to workout_sessions, cardio_entries, and body_measurements as plain integers with no FK constraint. The admin delete endpoint cascaded child data manually in Python, but a raw DB-level DELETE FROM users would either fail with FK violation (if a previous create_all had added the constraint) or leave orphaned rows.

Added ondelete="CASCADE" to all three model ForeignKey declarations and wrote migration g3h5i7j9k1l2 which drops any existing FK without CASCADE and recreates it with ON DELETE CASCADE. Added 9 tests: FK existence, schema-level CASCADE inspection, and behavioural raw-delete assertions for all three tables.

Closes #184