### PR TITLE
fix: return 403 Account disabled instead of 401 Invalid credentials (…

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -98,12 +98,12 @@ def change_password(
 @limiter.limit("5/minute")
 def login(request: Request, body: LoginRequest, db: Session = Depends(get_db)):
     user = db.query(User).filter(User.username == body.username).first()
-    if (
-        not user
-        or not user.is_active
-        or not verify_password(body.password, user.hashed_password)
-    ):
+    if not user or not verify_password(body.password, user.hashed_password):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials"
+        )
+    if not user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Account disabled"
         )
     return TokenResponse(access_token=create_access_token(user.id))

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -174,7 +174,7 @@ def test_disable_user_prevents_login(client: TestClient):
             "/api/auth/login",
             json={"username": "to_be_disabled", "password": "pass1234"},
         ).status_code
-        == 401
+        == 403
     )
 
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -282,3 +282,60 @@ def test_expired_token_rejected_on_any_protected_endpoint(client: TestClient):
     headers = {"Authorization": f"Bearer {token}"}
     assert client.get("/api/exercises", headers=headers).status_code == 401
     assert client.get("/api/stats/home", headers=headers).status_code == 401
+
+
+# ── Disabled account login (#189) ─────────────────────────────────────────────
+
+
+def _make_disabled_user(username: str) -> None:
+    db = SessionLocal()
+    db.add(
+        User(
+            username=username,
+            hashed_password=bcrypt.hashpw(
+                b"pass1234", bcrypt.gensalt(rounds=4)
+            ).decode(),
+            is_active=False,
+            is_admin=False,
+            created_at=datetime.now(timezone.utc),
+        )
+    )
+    db.commit()
+    db.close()
+
+
+def test_disabled_account_returns_403(client: TestClient):
+    _make_disabled_user("disabled_user_403")
+    resp = client.post(
+        "/api/auth/login",
+        json={"username": "disabled_user_403", "password": "pass1234"},
+    )
+    assert resp.status_code == 403
+
+
+def test_disabled_account_detail_mentions_disabled(client: TestClient):
+    _make_disabled_user("disabled_user_detail")
+    resp = client.post(
+        "/api/auth/login",
+        json={"username": "disabled_user_detail", "password": "pass1234"},
+    )
+    assert "disabled" in resp.json()["detail"].lower()
+
+
+def test_disabled_account_wrong_password_returns_401(client: TestClient):
+    """Wrong password on a disabled account must not reveal the account is disabled."""
+    _make_disabled_user("disabled_user_wrong_pw")
+    resp = client.post(
+        "/api/auth/login",
+        json={"username": "disabled_user_wrong_pw", "password": "wrongpass"},
+    )
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Invalid credentials"
+
+
+def test_active_account_wrong_password_still_401(client: TestClient):
+    resp = client.post(
+        "/api/auth/login", json={"username": "testuser", "password": "wrongpass"}
+    )
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Invalid credentials"


### PR DESCRIPTION
…#189)

The login endpoint checked user existence, is_active, and password in a single condition, returning the same "Invalid credentials" 401 for all cases. A user whose account was disabled had no way to know why their correct credentials were rejected.

Split the check: wrong username or password returns 401 "Invalid credentials" (unchanged, does not leak account status); correct credentials on a disabled account returns 403 "Account disabled". Added four tests covering the 403 response, the detail message, that a wrong password on a disabled account still returns 401, and that active-account wrong passwords are unaffected. Updated test_admin.py to expect 403.

Closes #189