### PR TITLE
chore: cache node_modules and mypy in CI (#202)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,14 @@ jobs:
         working-directory: frontend
     steps:
       - uses: actions/checkout@v5
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v5
+        with:
+          path: frontend/node_modules
+          key: node-modules-${{ hashFiles('frontend/package-lock.json') }}
       - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
       - name: Build
         run: npm run build
@@ -34,6 +41,12 @@ jobs:
           path: ~/.cache/uv
           key: uv-${{ hashFiles('backend/requirements.txt', 'backend/requirements-dev.txt') }}
           restore-keys: uv-
+      - name: Cache mypy
+        uses: actions/cache@v5
+        with:
+          path: backend/.mypy_cache
+          key: mypy-${{ hashFiles('backend/requirements.txt', 'backend/requirements-dev.txt') }}
+          restore-keys: mypy-
       - name: Install dependencies
         run: |
           uv venv .venv


### PR DESCRIPTION
Every CI run was reinstalling node_modules from scratch and running mypy with a cold cache, adding unnecessary time on the self-hosted runner.

Added a node_modules cache keyed on package-lock.json hash; the Install dependencies step is skipped entirely on a cache hit. Added a .mypy_cache cache keyed on requirements file hashes; mypy restores stub and type analysis state between runs and only re-checks changed files.

Closes #202