### PR TITLE
M23 — Performance, security hardening, and test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,14 @@ jobs:
         working-directory: frontend
     steps:
       - uses: actions/checkout@v5
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v5
+        with:
+          path: frontend/node_modules
+          key: node-modules-${{ hashFiles('frontend/package-lock.json') }}
       - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
       - name: Build
         run: npm run build
@@ -34,6 +41,12 @@ jobs:
           path: ~/.cache/uv
           key: uv-${{ hashFiles('backend/requirements.txt', 'backend/requirements-dev.txt') }}
           restore-keys: uv-
+      - name: Cache mypy
+        uses: actions/cache@v5
+        with:
+          path: backend/.mypy_cache
+          key: mypy-${{ hashFiles('backend/requirements.txt', 'backend/requirements-dev.txt') }}
+          restore-keys: mypy-
       - name: Install dependencies
         run: |
           uv venv .venv

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -26,7 +26,7 @@ Fitman is a two-service web application: a Python REST API and a React single-pa
 ### Backend — FastAPI (Python)
 
 - Serves a REST JSON API consumed by the frontend
-- Handles authentication (JWT tokens)
+- Handles authentication (JWT tokens, bcrypt password hashing via `hash_password` / `verify_password` in `auth.py`)
 - Reads and writes all data to PostgreSQL via SQLAlchemy
 - Runs database migrations automatically on startup via Alembic
 - Attaches a `X-Request-ID` UUID header to every response for log tracing
@@ -140,6 +140,7 @@ exercises
 
 workout_sessions
   id          INTEGER PRIMARY KEY
+  user_id     INTEGER REFERENCES users(id) ON DELETE CASCADE
   session     TEXT NOT NULL          -- "Push A" | "Pull A" | "Legs A"
   started_at  TIMESTAMPTZ NOT NULL
   ended_at    TIMESTAMPTZ             -- null while in progress
@@ -158,6 +159,7 @@ logs
 ```
 cardio_entries
   id           INTEGER PRIMARY KEY
+  user_id      INTEGER REFERENCES users(id) ON DELETE CASCADE
   activity     TEXT NOT NULL          -- "Run" | "Walk" | "Bike" | "Swim" | "Row" | "Other"
   distance_m   REAL                   -- metres (null if not tracked)
   duration_s   INTEGER                -- seconds (null if not tracked)
@@ -170,6 +172,7 @@ cardio_entries
 ```
 body_measurements
   id                  INTEGER PRIMARY KEY
+  user_id             INTEGER REFERENCES users(id) ON DELETE CASCADE
   recorded_at         TIMESTAMPTZ NOT NULL
   weight_kg           REAL
   height_cm           REAL
@@ -285,7 +288,7 @@ The backend refuses to start if `SECRET_KEY` is missing.
 2. User registers via `POST /api/auth/register` — first user is automatically admin
 3. **Onboarding**: after registration, `fitman_onboarding_pending` is set in localStorage; the frontend redirects to `/onboarding` for a one-time profile setup step, then clears the flag and proceeds to home
 4. Subsequent logins: `POST /api/auth/login` with username + password
-5. Backend verifies against bcrypt hash stored in the `users` table, returns a JWT
+5. Backend verifies against bcrypt hash stored in the `users` table. Wrong username or password → 401 `"Invalid credentials"`. Correct credentials on a disabled account → 403 `"Account disabled"`. Returns a JWT on success.
 6. Frontend stores the token in localStorage and sends it as `Authorization: Bearer <token>` on every request
 7. JWT payload contains `user_id` as `sub`; `get_current_user` validates the token and fetches the user from DB
 8. Token expires after `JWT_EXPIRE_DAYS` days — user logs in again

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -30,6 +30,7 @@ Fitman is a two-service web application: a Python REST API and a React single-pa
 - Reads and writes all data to PostgreSQL via SQLAlchemy
 - Runs database migrations automatically on startup via Alembic
 - Attaches a `X-Request-ID` UUID header to every response for log tracing
+- Rate-limits the login endpoint to 5 requests per minute per IP (SlowAPI)
 - Runs on port `8000` inside Docker (internal only — not exposed to the host)
 
 ### Frontend — React + TypeScript
@@ -38,6 +39,7 @@ Fitman is a two-service web application: a Python REST API and a React single-pa
 - Communicates with the backend via nginx proxy (no direct connection to port 8000)
 - Tailwind CSS v4 for styling
 - In production: built to static files and served by nginx
+- nginx adds five HTTP security headers on every response: `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Content-Security-Policy`, and `Permissions-Policy`
 - In development: Vite dev server on port `5173` with `/api` proxy to backend
 
 ### Database — PostgreSQL 16
@@ -78,6 +80,7 @@ Fitman/
 │   │   └── versions/        # One file per schema change
 │   ├── alembic.ini
 │   ├── Dockerfile
+│   ├── .dockerignore        # Excludes .env, .venv, tests/, __pycache__, dev deps from image
 │   ├── requirements.txt
 │   ├── requirements-dev.txt # Dev/CI dependencies (pytest, ruff, mypy)
 │   ├── pyproject.toml       # Ruff and mypy configuration

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fitman
 
-[![CI](https://github.com/Dave-Nijhuis/Fitman/actions/workflows/ci.yml/badge.svg)](https://github.com/Dave-Nijhuis/Fitman/actions/workflows/ci.yml)
+[![CI](https://github.com/DaveNijhuis/Fitman/actions/workflows/ci.yml/badge.svg)](https://github.com/DaveNijhuis/Fitman/actions/workflows/ci.yml)
 [![Python](https://img.shields.io/badge/python-3.11+-blue?logo=python&logoColor=white)](https://www.python.org/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-009688?logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com/)
 [![React](https://img.shields.io/badge/React-18-61DAFB?logo=react&logoColor=black)](https://react.dev/)
@@ -9,7 +9,7 @@
 [![Docker](https://img.shields.io/badge/Docker-ready-2496ED?logo=docker&logoColor=white)](https://www.docker.com/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-175%20passing-brightgreen)](TESTING.md)
+[![Tests](https://img.shields.io/badge/tests-188%20passing-brightgreen)](TESTING.md)
 
 A self-hosted fitness tracking app. Log workouts, track progress, own your data.
 
@@ -67,7 +67,7 @@ In the [Tailscale admin console](https://login.tailscale.com/admin/machines), re
 
 ```bash
 # Clone the repo on your server
-git clone https://github.com/Dave-Nijhuis/Fitman.git
+git clone https://github.com/DaveNijhuis/Fitman.git
 cd Fitman
 
 # Set up environment variables
@@ -219,7 +219,7 @@ All work flows through feature branches → `dev` → `main` via pull request.
 
 ## Project board
 
-Issues and feature tracking are managed in the [GitHub Project](https://github.com/users/Dave-Nijhuis/projects/3).
+Issues and feature tracking are managed in the [GitHub Project](https://github.com/users/DaveNijhuis/projects/3).
 
 ## Built with AI
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Docker](https://img.shields.io/badge/Docker-ready-2496ED?logo=docker&logoColor=white)](https://www.docker.com/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-188%20passing-brightgreen)](TESTING.md)
+[![Tests](https://img.shields.io/badge/tests-220%20passing-brightgreen)](TESTING.md)
 
 A self-hosted fitness tracking app. Log workouts, track progress, own your data.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -64,6 +64,9 @@ All tests live in `backend/tests/`. The suite runs against a real PostgreSQL dat
 | `test_postgresql.py` | PostgreSQL migration structural tests: engine dialect is postgresql, no TZDateTime custom type in any model |
 | `test_middleware.py` | Request ID middleware: `X-Request-ID` header present on all responses, value is a valid UUID4, unique per request |
 | `test_health.py` | `GET /health` returns 200 under normal conditions; returns 503 with `{"status": "error"}` when the database is unreachable (tested via dependency override) |
+| `test_ratelimit.py` | Login rate limiting: 6th request within a minute returns 429; health endpoint is not rate-limited |
+| `test_nginx_conf.py` | Static parse of `frontend/nginx.conf`: asserts all five security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Content-Security-Policy`, `Permissions-Policy`) are present |
+| `test_dockerignore.py` | Static parse of `backend/.dockerignore`: asserts `.env`, `.venv`, `tests/`, `__pycache__/`, and `requirements-dev.txt` are excluded from the Docker build context |
 
 ## conftest.py
 
@@ -73,6 +76,8 @@ A single `session`-scoped `TestClient` is shared across all tests. The database 
 - The full exercise library (via `seed.py`)
 
 Because the database is shared across tests, individual tests must not rely on the database being empty. Tests that need specific data insert it directly via `SessionLocal`.
+
+An `autouse=True` function-scoped fixture calls `limiter.reset()` before every test, clearing the in-memory rate limit counters so tests do not leak state across each other.
 
 `DATABASE_URL` must be set in the environment before the test session starts. `conftest.py` defaults to `postgresql://fitman:fitman@localhost:5432/fitman_test` if the variable is not set.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -47,26 +47,28 @@ All tests live in `backend/tests/`. The suite runs against a real PostgreSQL dat
 |---|---|
 | `test_indexes.py` | Schema index assertions: verifies that `logs.session_id`, `logs.exercise_id`, `workout_sessions.user_id`, `body_measurements.user_id`, and `cardio_entries.user_id` are indexed |
 | `test_admin.py` | Admin user management: list users, create, disable/enable, delete (with data cascade); 403 for non-admins, self-disable/delete blocked |
-| `test_auth.py` | Password hashing, login, registration validation (min length, consent required), JWT-protected endpoints, password change (wrong current → 400, short new → 422, success) |
+| `test_auth.py` | Password hashing, login, registration validation (min length, consent required), JWT-protected endpoints, password change (wrong current → 400, short new → 422, success); expired JWT rejected with 401; disabled account returns 403 with distinct message |
 | `test_cardio.py` | Cardio entry logging, list, delete, activity validation, schema contract (no `session_id`) |
 | `test_database_pool.py` | Connection pool configuration: verifies DB_POOL_SIZE, DB_MAX_OVERFLOW, DB_POOL_TIMEOUT env vars are read and applied; default values; uses `DATABASE_URL` from the environment (PostgreSQL) |
 | `test_entrypoint.py` | entrypoint.sh behaviour: non-zero exit and clear error message to stderr when migration fails; uvicorn not invoked on failure, invoked on success |
 | `test_exercises.py` | Exercise list (session + search filters), exercise by ID, sessions list |
-| `test_gdpr.py` | Right to erasure (401, 204, cascade delete); data export (401, structure, no password hash, Content-Disposition header, workout sessions included) |
+| `test_gdpr.py` | Right to erasure (401, 204, cascade delete); data export (401, structure, no password hash, Content-Disposition header, workout sessions included); fixture integrity check asserting seeded cardio activity is a valid title-case value |
 | `test_formulas.py` | Body composition formula calculations (BMI, fat mass, lean mass, BMR, segmental values) — pure unit tests, no HTTP |
 | `test_isolation.py` | Per-user data isolation: user B cannot read user A's sessions, cardio, or measurements |
 | `test_logs.py` | Set logging validation (`weight >= 0`, `reps > 0`), POST edge cases (bad IDs), GET last log, GET log list |
 | `test_measurements.py` | Body measurement CRUD, auth enforcement, full BIA formula application with impedance inputs |
-| `test_profile.py` | GET /api/profile structure and auth, PATCH updates (display_name, birth_year, sex, height_cm), unknown fields ignored, BIA falls back to profile height |
-| `test_progress.py` | Muscle balance, `epley_1rm` unit tests, strength progression (structure + daily best), volume over time, consistency heatmap, personal records |
+| `test_profile.py` | GET /api/profile structure and auth, PATCH updates (display_name, birth_year, sex, height_cm), unknown fields ignored, BIA falls back to profile height; sex rejects invalid values (422), birth_year rejects values outside 1900–current year (422) |
+| `test_progress.py` | Muscle balance, `epley_1rm` unit tests, strength progression (structure + daily best), volume over time, consistency heatmap, personal records; N+1 regression guard on consistency endpoint (asserts ≤2 SELECT statements) |
 | `test_sessions.py` | Full workout session flow: start → log sets → end → list → get logs; edge cases (unknown session, already ended, 404); N+1 query regression guard (asserts ≤2 SELECT statements on list endpoint); discard session (204 happy path, log cascade, cross-user 404, already-ended 400) |
-| `test_stats.py` | Home stats structure, streak calculation (unit + UTC correctness), week bounds (UTC correctness) |
+| `test_stats.py` | Home stats structure, streak calculation (unit + UTC correctness), week bounds (UTC correctness); memory regression guard asserting all workout_sessions SELECTs contain a started_at date bound |
 | `test_postgresql.py` | PostgreSQL migration structural tests: engine dialect is postgresql, no TZDateTime custom type in any model |
 | `test_middleware.py` | Request ID middleware: `X-Request-ID` header present on all responses, value is a valid UUID4, unique per request |
 | `test_health.py` | `GET /health` returns 200 under normal conditions; returns 503 with `{"status": "error"}` when the database is unreachable (tested via dependency override) |
 | `test_ratelimit.py` | Login rate limiting: 6th request within a minute returns 429; health endpoint is not rate-limited |
 | `test_nginx_conf.py` | Static parse of `frontend/nginx.conf`: asserts all five security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Content-Security-Policy`, `Permissions-Policy`) are present |
 | `test_dockerignore.py` | Static parse of `backend/.dockerignore`: asserts `.env`, `.venv`, `tests/`, `__pycache__/`, and `requirements-dev.txt` are excluded from the Docker build context |
+| `test_hash_password_dedup.py` | Asserts `hash_password` and `verify_password` are defined in `auth.py` and that neither `routers/auth.py` nor `routers/admin.py` defines its own private copy; identity check confirms both routers import the same function object |
+| `test_fk_cascade.py` | FK constraint existence on `workout_sessions`, `cardio_entries`, and `body_measurements` `user_id` columns; schema-level assertion that each FK has `ON DELETE CASCADE`; behavioural tests that raw `DELETE FROM users` cascades child rows in all three tables |
 
 ## conftest.py
 
@@ -109,4 +111,4 @@ Every push and pull request runs three jobs on a self-hosted runner:
 | **docker-build** | Builds the production Docker image to catch Dockerfile and dependency errors |
 | **frontend-build** | `npm ci`, `npm run build` — TypeScript compile + Vite bundle |
 
-The backend job uses `uv` for fast dependency installation with a cached wheel store. Typical CI time is ~30s per job.
+The backend job caches both the `uv` wheel store (keyed on requirements files) and the `.mypy_cache` directory (keyed on requirements files; mypy invalidates per-file internally). The frontend job caches `node_modules` keyed on `package-lock.json` and skips `npm ci` entirely on a cache hit.

--- a/backend/alembic/versions/g3h5i7j9k1l2_add_fk_cascade_on_user_id.py
+++ b/backend/alembic/versions/g3h5i7j9k1l2_add_fk_cascade_on_user_id.py
@@ -1,0 +1,66 @@
+"""add ON DELETE CASCADE to user_id FK constraints
+
+Revision ID: g3h5i7j9k1l2
+Revises: f1a2b3c4d5e6
+Create Date: 2026-07-12
+
+Migration b3d7f9e1c4a2 added user_id columns to workout_sessions,
+cardio_entries, and body_measurements as plain integers with no FK
+constraint. This migration adds the FK references to users.id with
+ON DELETE CASCADE so that deleting a user at the DB level automatically
+removes all their data, matching the application-level cascade in the
+admin delete endpoint.
+
+If a FK without CASCADE already exists (e.g. from an environment where
+create_all was run against an older model), it is dropped and recreated.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "g3h5i7j9k1l2"
+down_revision: Union[str, None] = "f1a2b3c4d5e6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_TABLES = ["workout_sessions", "cardio_entries", "body_measurements"]
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    for table in _TABLES:
+        existing = {fk["name"] for fk in inspector.get_foreign_keys(table)}
+        fk_name = f"{table}_user_id_fkey"
+        if fk_name in existing:
+            op.drop_constraint(fk_name, table, type_="foreignkey")
+        op.create_foreign_key(
+            fk_name,
+            table,
+            "users",
+            ["user_id"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    for table in _TABLES:
+        existing = {fk["name"] for fk in inspector.get_foreign_keys(table)}
+        fk_name = f"{table}_user_id_fkey"
+        if fk_name in existing:
+            op.drop_constraint(fk_name, table, type_="foreignkey")
+        # Restore FK without CASCADE
+        op.create_foreign_key(
+            fk_name,
+            table,
+            "users",
+            ["user_id"],
+            ["id"],
+        )

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -2,6 +2,7 @@ import os
 from datetime import datetime, timedelta, timezone
 from typing import Annotated
 
+import bcrypt
 import jwt
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -11,6 +12,15 @@ from database import get_db
 from models.user import User
 
 ALGORITHM = "HS256"
+
+
+def hash_password(plain: str) -> str:
+    return bcrypt.hashpw(plain.encode(), bcrypt.gensalt()).decode()
+
+
+def verify_password(plain: str, hashed: str) -> bool:
+    return bcrypt.checkpw(plain.encode(), hashed.encode())
+
 
 bearer = HTTPBearer()
 

--- a/backend/models/cardio.py
+++ b/backend/models/cardio.py
@@ -11,7 +11,7 @@ class CardioEntry(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     user_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("users.id"), nullable=False, index=True
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
     )
     activity: Mapped[str] = mapped_column(String, nullable=False)
     distance_m: Mapped[float | None] = mapped_column(Float)

--- a/backend/models/measurement.py
+++ b/backend/models/measurement.py
@@ -11,7 +11,7 @@ class BodyMeasurement(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     user_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("users.id"), nullable=False, index=True
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
     )
     recorded_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False

--- a/backend/models/workout.py
+++ b/backend/models/workout.py
@@ -11,7 +11,7 @@ class WorkoutSession(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     user_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("users.id"), nullable=False, index=True
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
     )
     session: Mapped[str] = mapped_column(String, nullable=False)
     started_at: Mapped[datetime] = mapped_column(

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1,12 +1,11 @@
 import logging
 from datetime import datetime, timezone
 
-import bcrypt
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.orm import Session
 
-from auth import get_current_user
+from auth import get_current_user, hash_password
 from database import get_db
 from models.cardio import CardioEntry
 from models.measurement import BodyMeasurement
@@ -24,10 +23,6 @@ def _require_admin(current_user: User = Depends(get_current_user)) -> User:
             status_code=status.HTTP_403_FORBIDDEN, detail="Admin access required"
         )
     return current_user
-
-
-def _hash_password(plain: str) -> str:
-    return bcrypt.hashpw(plain.encode(), bcrypt.gensalt()).decode()
 
 
 class UserOut(BaseModel):
@@ -75,7 +70,7 @@ def create_user(
         )
     user = User(
         username=body.username,
-        hashed_password=_hash_password(body.password),
+        hashed_password=hash_password(body.password),
         email=body.email,
         display_name=body.display_name,
         is_active=True,

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -2,12 +2,11 @@ import logging
 from datetime import datetime, timezone
 from typing import Literal
 
-import bcrypt
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
-from auth import create_access_token, get_current_user
+from auth import create_access_token, get_current_user, hash_password, verify_password
 from database import get_db
 from limiter import limiter
 from models.user import User
@@ -15,14 +14,6 @@ from models.user import User
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
-
-
-def _hash_password(plain: str) -> str:
-    return bcrypt.hashpw(plain.encode(), bcrypt.gensalt()).decode()
-
-
-def _verify_password(plain: str, hashed: str) -> bool:
-    return bcrypt.checkpw(plain.encode(), hashed.encode())
 
 
 class LoginRequest(BaseModel):
@@ -69,7 +60,7 @@ def register(body: RegisterRequest, db: Session = Depends(get_db)):
 
     user = User(
         username=body.username,
-        hashed_password=_hash_password(body.password),
+        hashed_password=hash_password(body.password),
         display_name=body.display_name,
         is_active=True,
         is_admin=True,  # first user is always admin
@@ -93,12 +84,12 @@ def change_password(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    if not _verify_password(body.current_password, current_user.hashed_password):
+    if not verify_password(body.current_password, current_user.hashed_password):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Current password is incorrect",
         )
-    current_user.hashed_password = _hash_password(body.new_password)
+    current_user.hashed_password = hash_password(body.new_password)
     db.commit()
     return {"detail": "Password updated"}
 
@@ -110,7 +101,7 @@ def login(request: Request, body: LoginRequest, db: Session = Depends(get_db)):
     if (
         not user
         or not user.is_active
-        or not _verify_password(body.password, user.hashed_password)
+        or not verify_password(body.password, user.hashed_password)
     ):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials"

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -98,12 +98,12 @@ def change_password(
 @limiter.limit("5/minute")
 def login(request: Request, body: LoginRequest, db: Session = Depends(get_db)):
     user = db.query(User).filter(User.username == body.username).first()
-    if (
-        not user
-        or not user.is_active
-        or not verify_password(body.password, user.hashed_password)
-    ):
+    if not user or not verify_password(body.password, user.hashed_password):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials"
+        )
+    if not user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Account disabled"
         )
     return TokenResponse(access_token=create_access_token(user.id))

--- a/backend/routers/profile.py
+++ b/backend/routers/profile.py
@@ -1,7 +1,9 @@
 import logging
+from datetime import datetime, timezone
+from typing import Literal
 
 from fastapi import APIRouter, Depends
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 from sqlalchemy.orm import Session
 
 from auth import get_current_user
@@ -28,8 +30,18 @@ class ProfileOut(BaseModel):
 class ProfilePatch(BaseModel):
     display_name: str | None = None
     birth_year: int | None = None
-    sex: str | None = None
+    sex: Literal["male", "female", "other"] | None = None
     height_cm: float | None = None
+
+    @field_validator("birth_year")
+    @classmethod
+    def birth_year_in_range(cls, v: int | None) -> int | None:
+        if v is None:
+            return v
+        current_year = datetime.now(timezone.utc).year
+        if not (1900 <= v <= current_year):
+            raise ValueError(f"birth_year must be between 1900 and {current_year}")
+        return v
 
 
 @router.get("", response_model=ProfileOut)

--- a/backend/routers/progress.py
+++ b/backend/routers/progress.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from auth import get_current_user
@@ -120,21 +121,24 @@ def consistency(
     current_user: User = Depends(get_current_user),
 ):
     cutoff = datetime.now(timezone.utc) - timedelta(weeks=17)
-    sessions = (
-        db.query(WorkoutSession)
+    rows = (
+        db.query(
+            WorkoutSession,
+            func.coalesce(func.sum(Log.weight * Log.reps), 0).label("volume"),
+        )
+        .outerjoin(Log, Log.session_id == WorkoutSession.id)
         .filter(
             WorkoutSession.user_id == current_user.id,
             WorkoutSession.started_at >= cutoff,
             WorkoutSession.ended_at.isnot(None),
         )
+        .group_by(WorkoutSession.id)
         .all()
     )
 
     trained_data: dict[str, dict] = {}
-    for s in sessions:
+    for s, volume in rows:
         date = s.started_at.date().isoformat()
-        logs = db.query(Log).filter(Log.session_id == s.id).all()
-        volume = sum(log.weight * log.reps for log in logs)
         trained_data[date] = {"session": s.session, "volume_kg": round(volume, 1)}
 
     now = datetime.now(timezone.utc)

--- a/backend/routers/stats.py
+++ b/backend/routers/stats.py
@@ -3,6 +3,7 @@ from datetime import date, datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
+from sqlalchemy import Date, cast, func
 from sqlalchemy.orm import Session
 
 from auth import get_current_user
@@ -58,51 +59,73 @@ def home_stats(
     current_user: User = Depends(get_current_user),
 ):
     week_start, week_end = _iso_week_bounds()
+    week_start_dt = datetime.fromisoformat(week_start).replace(tzinfo=timezone.utc)
+    week_end_dt = datetime.fromisoformat(week_end).replace(
+        tzinfo=timezone.utc
+    ) + timedelta(days=1)
 
-    prev_start = (date.fromisoformat(week_start) - timedelta(weeks=1)).isoformat()
-    prev_end = (date.fromisoformat(week_end) - timedelta(weeks=1)).isoformat()
+    prev_start_dt = week_start_dt - timedelta(weeks=1)
+    prev_end_dt = week_end_dt - timedelta(weeks=1)
 
-    all_sessions = (
-        db.query(WorkoutSession)
+    # Streak — date-only query bounded to 365 days (covers any realistic streak)
+    streak_cutoff = datetime.now(timezone.utc) - timedelta(days=365)
+    trained_dates = {
+        row[0].isoformat()
+        for row in db.query(cast(WorkoutSession.started_at, Date))
         .filter(
             WorkoutSession.user_id == current_user.id,
             WorkoutSession.ended_at.isnot(None),
+            WorkoutSession.started_at >= streak_cutoff,
         )
         .all()
-    )
-    trained_dates = {s.started_at.date().isoformat() for s in all_sessions}
+    }
     streak = _compute_streak(trained_dates)
 
-    week_sessions = [
-        s
-        for s in all_sessions
-        if week_start <= s.started_at.date().isoformat() <= week_end
-    ]
-    week_workouts = len(week_sessions)
-
-    week_session_ids = {s.id for s in week_sessions}
-    week_logs = (
-        db.query(Log).filter(Log.session_id.in_(week_session_ids)).all()
-        if week_session_ids
-        else []
+    # Current week — single aggregated query
+    week_row = (
+        db.query(
+            func.count(WorkoutSession.id.distinct()).label("workouts"),
+            func.coalesce(func.sum(Log.weight * Log.reps), 0).label("volume"),
+            func.coalesce(
+                func.sum(
+                    func.extract(
+                        "epoch", WorkoutSession.ended_at - WorkoutSession.started_at
+                    )
+                    / 60
+                ),
+                0,
+            ).label("minutes"),
+        )
+        .select_from(WorkoutSession)
+        .outerjoin(Log, Log.session_id == WorkoutSession.id)
+        .filter(
+            WorkoutSession.user_id == current_user.id,
+            WorkoutSession.ended_at.isnot(None),
+            WorkoutSession.started_at >= week_start_dt,
+            WorkoutSession.started_at < week_end_dt,
+        )
+        .one()
     )
-    week_volume = round(sum(log.weight * log.reps for log in week_logs), 1)
+    week_workouts = week_row.workouts
+    week_volume = round(float(week_row.volume), 1)
+    week_minutes = int(week_row.minutes)
 
-    week_minutes = 0
-    for s in week_sessions:
-        if s.ended_at:
-            week_minutes += int((s.ended_at - s.started_at).total_seconds() / 60)
-
-    prev_sessions = [
-        s
-        for s in all_sessions
-        if prev_start <= s.started_at.date().isoformat() <= prev_end
-    ]
-    prev_ids = {s.id for s in prev_sessions}
-    prev_logs = (
-        db.query(Log).filter(Log.session_id.in_(prev_ids)).all() if prev_ids else []
+    # Previous week volume — single aggregated query
+    prev_row = (
+        db.query(
+            func.coalesce(func.sum(Log.weight * Log.reps), 0).label("volume"),
+        )
+        .select_from(WorkoutSession)
+        .outerjoin(Log, Log.session_id == WorkoutSession.id)
+        .filter(
+            WorkoutSession.user_id == current_user.id,
+            WorkoutSession.ended_at.isnot(None),
+            WorkoutSession.started_at >= prev_start_dt,
+            WorkoutSession.started_at < prev_end_dt,
+        )
+        .one()
     )
-    prev_week_volume = round(sum(log.weight * log.reps for log in prev_logs), 1)
+    prev_week_volume = round(float(prev_row.volume), 1)
 
     return HomeStats(
         streak=streak,

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -174,7 +174,7 @@ def test_disable_user_prevents_login(client: TestClient):
             "/api/auth/login",
             json={"username": "to_be_disabled", "password": "pass1234"},
         ).status_code
-        == 401
+        == 403
     )
 
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,8 +1,11 @@
-from datetime import datetime, timezone
+import os
+from datetime import datetime, timedelta, timezone
 
 import bcrypt
+import jwt
 from fastapi.testclient import TestClient
 
+from auth import ALGORITHM
 from auth import verify_password as _verify_password
 from database import SessionLocal
 from models.user import User
@@ -246,3 +249,36 @@ def test_consent_given_at_column_exists(client: TestClient):
     assert user is not None
     assert hasattr(user, "consent_given_at")
     db.close()
+
+
+# ── Expired JWT (#182) ────────────────────────────────────────────────────────
+
+
+def _expired_token(user_id: int) -> str:
+    expired = datetime.now(timezone.utc) - timedelta(seconds=1)
+    return jwt.encode(
+        {"sub": str(user_id), "exp": expired},
+        os.getenv("SECRET_KEY"),
+        algorithm=ALGORITHM,
+    )
+
+
+def test_expired_token_returns_401(client: TestClient):
+    token = _expired_token(1)
+    resp = client.get("/api/profile", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401
+
+
+def test_expired_token_detail_is_invalid_token(client: TestClient):
+    """Response body must say 'Invalid token', not leak expiry details."""
+    token = _expired_token(1)
+    resp = client.get("/api/profile", headers={"Authorization": f"Bearer {token}"})
+    assert resp.json()["detail"] == "Invalid token"
+
+
+def test_expired_token_rejected_on_any_protected_endpoint(client: TestClient):
+    """Expiry check applies to all protected routes, not just /api/profile."""
+    token = _expired_token(1)
+    headers = {"Authorization": f"Bearer {token}"}
+    assert client.get("/api/exercises", headers=headers).status_code == 401
+    assert client.get("/api/stats/home", headers=headers).status_code == 401

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -282,3 +282,60 @@ def test_expired_token_rejected_on_any_protected_endpoint(client: TestClient):
     headers = {"Authorization": f"Bearer {token}"}
     assert client.get("/api/exercises", headers=headers).status_code == 401
     assert client.get("/api/stats/home", headers=headers).status_code == 401
+
+
+# ── Disabled account login (#189) ─────────────────────────────────────────────
+
+
+def _make_disabled_user(username: str) -> None:
+    db = SessionLocal()
+    db.add(
+        User(
+            username=username,
+            hashed_password=bcrypt.hashpw(
+                b"pass1234", bcrypt.gensalt(rounds=4)
+            ).decode(),
+            is_active=False,
+            is_admin=False,
+            created_at=datetime.now(timezone.utc),
+        )
+    )
+    db.commit()
+    db.close()
+
+
+def test_disabled_account_returns_403(client: TestClient):
+    _make_disabled_user("disabled_user_403")
+    resp = client.post(
+        "/api/auth/login",
+        json={"username": "disabled_user_403", "password": "pass1234"},
+    )
+    assert resp.status_code == 403
+
+
+def test_disabled_account_detail_mentions_disabled(client: TestClient):
+    _make_disabled_user("disabled_user_detail")
+    resp = client.post(
+        "/api/auth/login",
+        json={"username": "disabled_user_detail", "password": "pass1234"},
+    )
+    assert "disabled" in resp.json()["detail"].lower()
+
+
+def test_disabled_account_wrong_password_returns_401(client: TestClient):
+    """Wrong password on a disabled account must not reveal the account is disabled."""
+    _make_disabled_user("disabled_user_wrong_pw")
+    resp = client.post(
+        "/api/auth/login",
+        json={"username": "disabled_user_wrong_pw", "password": "wrongpass"},
+    )
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Invalid credentials"
+
+
+def test_active_account_wrong_password_still_401(client: TestClient):
+    resp = client.post(
+        "/api/auth/login", json={"username": "testuser", "password": "wrongpass"}
+    )
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Invalid credentials"

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -3,9 +3,9 @@ from datetime import datetime, timezone
 import bcrypt
 from fastapi.testclient import TestClient
 
+from auth import verify_password as _verify_password
 from database import SessionLocal
 from models.user import User
-from routers.auth import _verify_password
 
 # ── Unit tests ────────────────────────────────────────────────────────────────
 

--- a/backend/tests/test_fk_cascade.py
+++ b/backend/tests/test_fk_cascade.py
@@ -1,0 +1,144 @@
+"""FK constraint + ON DELETE CASCADE tests (#184).
+
+The test DB is built via Base.metadata.create_all so FK declarations on the
+models are what drive these tests. The Alembic migration must also be updated
+for production, but correctness is proved here at the model level.
+"""
+
+from datetime import datetime, timezone
+
+import bcrypt
+from sqlalchemy import inspect, text
+
+from database import SessionLocal, engine
+from models.cardio import CardioEntry
+from models.measurement import BodyMeasurement
+from models.user import User
+from models.workout import WorkoutSession
+
+
+def _user_id_fk(table: str) -> dict | None:
+    for fk in inspect(engine).get_foreign_keys(table):
+        if "user_id" in fk["constrained_columns"]:
+            return fk
+    return None
+
+
+# ── FK constraint exists ───────────────────────────────────────────────────────
+
+
+def test_workout_sessions_user_id_fk_exists():
+    assert _user_id_fk("workout_sessions") is not None
+
+
+def test_cardio_entries_user_id_fk_exists():
+    assert _user_id_fk("cardio_entries") is not None
+
+
+def test_body_measurements_user_id_fk_exists():
+    assert _user_id_fk("body_measurements") is not None
+
+
+# ── ON DELETE CASCADE ─────────────────────────────────────────────────────────
+
+
+def test_workout_sessions_user_id_fk_has_cascade_delete():
+    fk = _user_id_fk("workout_sessions")
+    assert fk is not None
+    assert fk.get("options", {}).get("ondelete", "").upper() == "CASCADE", (
+        f"workout_sessions.user_id FK missing ON DELETE CASCADE; options={fk.get('options')}"
+    )
+
+
+def test_cardio_entries_user_id_fk_has_cascade_delete():
+    fk = _user_id_fk("cardio_entries")
+    assert fk is not None
+    assert fk.get("options", {}).get("ondelete", "").upper() == "CASCADE", (
+        f"cardio_entries.user_id FK missing ON DELETE CASCADE; options={fk.get('options')}"
+    )
+
+
+def test_body_measurements_user_id_fk_has_cascade_delete():
+    fk = _user_id_fk("body_measurements")
+    assert fk is not None
+    assert fk.get("options", {}).get("ondelete", "").upper() == "CASCADE", (
+        f"body_measurements.user_id FK missing ON DELETE CASCADE; options={fk.get('options')}"
+    )
+
+
+# ── Behavioural: raw delete cascades to child rows ────────────────────────────
+
+
+def _make_user_with_data() -> int:
+    db = SessionLocal()
+    user = User(
+        username=f"cascade_test_{datetime.now(timezone.utc).timestamp()}",
+        hashed_password=bcrypt.hashpw(b"pass1234", bcrypt.gensalt(rounds=4)).decode(),
+        is_active=True,
+        is_admin=False,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    user_id = user.id
+
+    db.add(
+        WorkoutSession(
+            user_id=user_id,
+            session="Push A",
+            started_at=datetime.now(timezone.utc),
+            ended_at=datetime.now(timezone.utc),
+        )
+    )
+    db.add(
+        CardioEntry(
+            user_id=user_id,
+            activity="Run",
+            duration_s=600,
+            logged_at=datetime.now(timezone.utc),
+        )
+    )
+    db.add(
+        BodyMeasurement(
+            user_id=user_id,
+            weight_kg=75.0,
+            recorded_at=datetime.now(timezone.utc),
+        )
+    )
+    db.commit()
+    db.close()
+    return user_id
+
+
+def test_raw_user_delete_cascades_workout_sessions():
+    user_id = _make_user_with_data()
+    with engine.connect() as conn:
+        conn.execute(text("DELETE FROM users WHERE id = :uid"), {"uid": user_id})
+        conn.commit()
+    db = SessionLocal()
+    count = db.query(WorkoutSession).filter(WorkoutSession.user_id == user_id).count()
+    db.close()
+    assert count == 0, f"Expected 0 workout_sessions after user delete, got {count}"
+
+
+def test_raw_user_delete_cascades_cardio_entries():
+    user_id = _make_user_with_data()
+    with engine.connect() as conn:
+        conn.execute(text("DELETE FROM users WHERE id = :uid"), {"uid": user_id})
+        conn.commit()
+    db = SessionLocal()
+    count = db.query(CardioEntry).filter(CardioEntry.user_id == user_id).count()
+    db.close()
+    assert count == 0, f"Expected 0 cardio_entries after user delete, got {count}"
+
+
+def test_raw_user_delete_cascades_body_measurements():
+    user_id = _make_user_with_data()
+    with engine.connect() as conn:
+        conn.execute(text("DELETE FROM users WHERE id = :uid"), {"uid": user_id})
+        conn.commit()
+    db = SessionLocal()
+    count = db.query(BodyMeasurement).filter(BodyMeasurement.user_id == user_id).count()
+    db.close()
+    assert count == 0, f"Expected 0 body_measurements after user delete, got {count}"

--- a/backend/tests/test_gdpr.py
+++ b/backend/tests/test_gdpr.py
@@ -57,7 +57,7 @@ def _seed_data(user_id: int) -> None:
     db.add(
         CardioEntry(
             user_id=user_id,
-            activity="run",
+            activity="Run",
             duration_s=1800,
             logged_at=datetime.now(timezone.utc),
         )
@@ -195,3 +195,28 @@ def test_export_includes_workout_sessions(client: TestClient):
     data = client.get("/api/gdpr/export", headers=headers).json()
     assert isinstance(data["workout_sessions"], list)
     assert any(s["id"] == session["id"] for s in data["workout_sessions"])
+
+
+# ── Fixture data integrity (#183) ─────────────────────────────────────────────
+
+
+def test_seed_data_cardio_activity_is_valid(client: TestClient):
+    """_seed_data must seed a valid title-case activity, not a raw lowercase string.
+
+    CardioEntry is inserted directly into the DB so the API validation in
+    POST /api/cardio is bypassed. If the activity value is wrong it silently
+    persists and pollutes GDPR exports with invalid data.
+    """
+    from routers.cardio import ACTIVITIES
+
+    user_id = _make_user("seed_activity_check")
+    _seed_data(user_id)
+
+    db = SessionLocal()
+    entry = db.query(CardioEntry).filter(CardioEntry.user_id == user_id).first()
+    db.close()
+
+    assert entry is not None
+    assert entry.activity in ACTIVITIES, (
+        f"Seeded activity {entry.activity!r} is not a valid value; expected one of {ACTIVITIES}"
+    )

--- a/backend/tests/test_hash_password_dedup.py
+++ b/backend/tests/test_hash_password_dedup.py
@@ -1,0 +1,57 @@
+"""Verify _hash_password is defined once in auth.py, not duplicated in routers."""
+
+import inspect
+
+import routers.admin as admin_module
+import routers.auth as auth_router_module
+
+
+def test_hash_password_lives_in_auth():
+    """auth.hash_password must be importable and produce a valid bcrypt hash."""
+    from auth import hash_password, verify_password
+
+    hashed = hash_password("secret123")
+    assert hashed != "secret123"
+    assert hashed.startswith("$2b$")
+    assert verify_password("secret123", hashed)
+    assert not verify_password("wrong", hashed)
+
+
+def test_auth_router_does_not_define_hash_password():
+    """routers/auth.py must not define its own _hash_password."""
+    assert not hasattr(auth_router_module, "_hash_password"), (
+        "routers/auth.py still defines _hash_password — remove it and import from auth"
+    )
+
+
+def test_admin_does_not_define_hash_password():
+    """routers/admin.py must not define its own _hash_password."""
+    assert not hasattr(admin_module, "_hash_password"), (
+        "routers/admin.py still defines _hash_password — remove it and import from auth"
+    )
+
+
+def test_routers_share_same_hash_function():
+    """Both routers must use the same hash_password from auth, not separate copies."""
+    from auth import hash_password
+
+    # Both modules must reference the canonical function from auth
+    auth_router_fn = getattr(auth_router_module, "hash_password", None)
+    admin_fn = getattr(admin_module, "hash_password", None)
+
+    assert auth_router_fn is hash_password, (
+        "routers/auth.py does not import hash_password from auth"
+    )
+    assert admin_fn is hash_password, (
+        "routers/admin.py does not import hash_password from auth"
+    )
+
+
+def test_hash_password_source_is_auth_module():
+    """hash_password must be defined in auth.py, not in any router."""
+    from auth import hash_password
+
+    source_file = inspect.getfile(hash_password)
+    assert source_file.endswith("auth.py") and "routers" not in source_file, (
+        f"hash_password is defined in {source_file}, expected backend/auth.py"
+    )

--- a/backend/tests/test_profile.py
+++ b/backend/tests/test_profile.py
@@ -71,6 +71,70 @@ def test_patch_profile_ignores_unknown_fields(client: TestClient):
     assert resp.status_code == 200
 
 
+# ── Input validation (#181) ───────────────────────────────────────────────────
+
+
+def test_patch_sex_invalid_value_returns_422(client: TestClient):
+    resp = client.patch("/api/profile", json={"sex": "banana"}, headers=_auth(client))
+    assert resp.status_code == 422
+
+
+def test_patch_sex_empty_string_returns_422(client: TestClient):
+    resp = client.patch("/api/profile", json={"sex": ""}, headers=_auth(client))
+    assert resp.status_code == 422
+
+
+def test_patch_sex_accepts_all_valid_values(client: TestClient):
+    headers = _auth(client)
+    for value in ("male", "female", "other"):
+        resp = client.patch("/api/profile", json={"sex": value}, headers=headers)
+        assert resp.status_code == 200, (
+            f"Expected 200 for sex={value!r}, got {resp.status_code}"
+        )
+        assert resp.json()["sex"] == value
+
+
+def test_patch_birth_year_below_minimum_returns_422(client: TestClient):
+    resp = client.patch(
+        "/api/profile", json={"birth_year": 1899}, headers=_auth(client)
+    )
+    assert resp.status_code == 422
+
+
+def test_patch_birth_year_negative_returns_422(client: TestClient):
+    resp = client.patch("/api/profile", json={"birth_year": -1}, headers=_auth(client))
+    assert resp.status_code == 422
+
+
+def test_patch_birth_year_future_returns_422(client: TestClient):
+    from datetime import datetime
+
+    future_year = datetime.now().year + 1
+    resp = client.patch(
+        "/api/profile", json={"birth_year": future_year}, headers=_auth(client)
+    )
+    assert resp.status_code == 422
+
+
+def test_patch_birth_year_minimum_boundary_valid(client: TestClient):
+    resp = client.patch(
+        "/api/profile", json={"birth_year": 1900}, headers=_auth(client)
+    )
+    assert resp.status_code == 200
+    assert resp.json()["birth_year"] == 1900
+
+
+def test_patch_birth_year_current_year_valid(client: TestClient):
+    from datetime import datetime
+
+    current_year = datetime.now().year
+    resp = client.patch(
+        "/api/profile", json={"birth_year": current_year}, headers=_auth(client)
+    )
+    assert resp.status_code == 200
+    assert resp.json()["birth_year"] == current_year
+
+
 # ── Profile fields used as BIA fallback ───────────────────────────────────────
 
 

--- a/backend/tests/test_progress.py
+++ b/backend/tests/test_progress.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from fastapi.testclient import TestClient
 
@@ -300,6 +300,65 @@ def test_prs_picks_best_set_per_exercise(client: TestClient):
     assert match["estimated_1rm"] >= 100.0
     assert "exercise_name" in match
     assert "date" in match
+
+
+# ── N+1 regression (#178) ────────────────────────────────────────────────────
+
+
+def test_consistency_single_query(client: TestClient):
+    """GET /api/progress/consistency must not fire one query per session (N+1).
+
+    Seeds 5 completed sessions with logs directly in the DB, then counts
+    SELECT statements during the consistency request. The current implementation
+    fires 1 (sessions fetch) + 5 (one logs query per session) = 6 queries.
+    The fix aggregates volume in SQL so the total must be ≤2 (auth + one query).
+    """
+    from sqlalchemy import event
+
+    from database import SessionLocal, engine
+
+    db = SessionLocal()
+    ex = db.query(Exercise).filter(Exercise.session == "Push A").first()
+    assert ex is not None
+    exercise_id = ex.id
+    now = datetime.now(timezone.utc)
+    for i in range(5):
+        s = WorkoutSession(
+            user_id=1,
+            session="Push A",
+            started_at=now - timedelta(days=i + 2),
+            ended_at=now - timedelta(days=i + 1),
+        )
+        db.add(s)
+        db.flush()
+        db.add(
+            Log(
+                session_id=s.id,
+                exercise_id=exercise_id,
+                weight=50.0,
+                reps=8,
+                logged_at=now - timedelta(days=i + 2),
+            )
+        )
+    db.commit()
+    db.close()
+
+    headers = _auth(client)
+    query_count = 0
+
+    def _count(conn, cursor, statement, parameters, context, executemany):
+        nonlocal query_count
+        if statement.strip().upper().startswith("SELECT"):
+            query_count += 1
+
+    event.listen(engine, "before_cursor_execute", _count)
+    try:
+        resp = client.get("/api/progress/consistency", headers=headers)
+    finally:
+        event.remove(engine, "before_cursor_execute", _count)
+
+    assert resp.status_code == 200
+    assert query_count <= 2, f"N+1 detected: {query_count} SELECT queries (expected ≤2)"
 
 
 # ── N+1 regression (#130) ─────────────────────────────────────────────────────

--- a/backend/tests/test_stats.py
+++ b/backend/tests/test_stats.py
@@ -88,6 +88,47 @@ def test_streak_uses_utc_not_local_date():
         assert streak == 1
 
 
+# ── Memory regression (#179) ──────────────────────────────────────────────────
+
+
+def test_home_stats_sessions_query_has_date_bound(client: TestClient):
+    """GET /api/stats/home must not issue an unbounded sessions SELECT.
+
+    The pre-fix implementation loads every completed session for the user
+    into memory and filters by date in Python.  The fix pushes all date
+    filtering into SQL so no query touches the full history.
+
+    Asserts that every workout_sessions SELECT issued during the request
+    contains a started_at bound in its WHERE clause.
+    """
+    from sqlalchemy import event
+
+    from database import engine
+
+    unbounded: list[str] = []
+
+    def _inspect(conn, cursor, statement, *args):
+        lower = statement.lower()
+        if (
+            "workout_session" in lower
+            and lower.lstrip().startswith("select")
+            and "started_at >=" not in lower
+            and "started_at <" not in lower
+        ):
+            unbounded.append(statement)
+
+    event.listen(engine, "before_cursor_execute", _inspect)
+    try:
+        resp = client.get("/api/stats/home", headers=_auth(client))
+    finally:
+        event.remove(engine, "before_cursor_execute", _inspect)
+
+    assert resp.status_code == 200
+    assert not unbounded, (
+        f"Unbounded sessions query (no date filter):\n{unbounded[0][:300]}"
+    )
+
+
 # ── Unit tests for _iso_week_bounds ───────────────────────────────────────────
 
 


### PR DESCRIPTION
### What changed

**Performance**
- Fixed N+1 query in `GET /api/progress/consistency`: volume is now aggregated in SQL with a single outerjoin instead of one query per session (#178)
- Fixed unbounded memory load in `GET /api/stats/home`: replaced a full session scan with three targeted SQL queries, each with explicit `started_at` date bounds (#179)

**Security & correctness**
- `POST /api/auth/login` now returns 403 `"Account disabled"` for valid credentials on a disabled account, instead of the same 401 `"Invalid credentials"` returned for wrong passwords (#189)
- `PATCH /api/profile` now validates `sex` against `Literal["male", "female", "other"]` and `birth_year` against `1900–current year`; both violations return 422 (#181)
- Added `ON DELETE CASCADE` to `user_id` FK constraints on `workout_sessions`, `cardio_entries`, and `body_measurements` — migration `g3h5i7j9k1l2` (#184)

**Code quality**
- Deduplicated `_hash_password` / `_verify_password`: both now live in `auth.py` as public `hash_password` / `verify_password`; both routers import from there (#180)
- Fixed GDPR test fixture: `activity="run"` → `"Run"` to match the valid title-case `ACTIVITIES` list (#183)

**CI**
- Cached `node_modules` (keyed on `package-lock.json`) and `.mypy_cache` (keyed on requirements files); frontend skips `npm ci` on cache hit (#202)

**Test coverage** (190 → 220 tests)
- Expired JWT tokens rejected with 401 (#182)
- `test_hash_password_dedup.py`: 5 tests asserting the single-source-of-truth for password helpers
- `test_fk_cascade.py`: 9 tests — FK existence, CASCADE schema inspection, and behavioural raw-delete cascade on all three user data tables

### Docs updated
- `README.md`: test badge 188 → 220
- `ARCHITECTURE.md`: FK CASCADE in schema, 403 for disabled login, `auth.py` as home for password helpers
- `TESTING.md`: new test files, updated descriptions, CI cache notes
