### PR TITLE
fix: make create_index calls idempotent in migration e2f9a3b7c1d5 (#231)

### DIFF
--- a/backend/alembic/versions/e2f9a3b7c1d5_add_indexes_on_logs_and_measurements.py
+++ b/backend/alembic/versions/e2f9a3b7c1d5_add_indexes_on_logs_and_measurements.py
@@ -16,16 +16,16 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.create_index("ix_logs_session_id", "logs", ["session_id"])
-    op.create_index("ix_logs_exercise_id", "logs", ["exercise_id"])
-    op.create_index("ix_workout_sessions_user_id", "workout_sessions", ["user_id"])
-    op.create_index("ix_body_measurements_user_id", "body_measurements", ["user_id"])
-    op.create_index("ix_cardio_entries_user_id", "cardio_entries", ["user_id"])
+    op.create_index("ix_logs_session_id", "logs", ["session_id"], if_not_exists=True)
+    op.create_index("ix_logs_exercise_id", "logs", ["exercise_id"], if_not_exists=True)
+    op.create_index("ix_workout_sessions_user_id", "workout_sessions", ["user_id"], if_not_exists=True)
+    op.create_index("ix_body_measurements_user_id", "body_measurements", ["user_id"], if_not_exists=True)
+    op.create_index("ix_cardio_entries_user_id", "cardio_entries", ["user_id"], if_not_exists=True)
 
 
 def downgrade() -> None:
-    op.drop_index("ix_logs_session_id", table_name="logs")
-    op.drop_index("ix_logs_exercise_id", table_name="logs")
-    op.drop_index("ix_workout_sessions_user_id", table_name="workout_sessions")
-    op.drop_index("ix_body_measurements_user_id", table_name="body_measurements")
-    op.drop_index("ix_cardio_entries_user_id", table_name="cardio_entries")
+    op.drop_index("ix_logs_session_id", table_name="logs", if_exists=True)
+    op.drop_index("ix_logs_exercise_id", table_name="logs", if_exists=True)
+    op.drop_index("ix_workout_sessions_user_id", table_name="workout_sessions", if_exists=True)
+    op.drop_index("ix_body_measurements_user_id", table_name="body_measurements", if_exists=True)
+    op.drop_index("ix_cardio_entries_user_id", table_name="cardio_entries", if_exists=True)

--- a/backend/tests/test_indexes.py
+++ b/backend/tests/test_indexes.py
@@ -4,6 +4,11 @@ The test DB is built via Base.metadata.create_all so indexes must be declared
 on the models — not only in Alembic — to be picked up here.
 """
 
+import importlib.util
+from pathlib import Path
+
+from alembic.operations import Operations
+from alembic.runtime.migration import MigrationContext
 from sqlalchemy import inspect
 
 from database import engine
@@ -41,3 +46,24 @@ def test_body_measurements_user_id_is_indexed():
 def test_cardio_entries_user_id_is_indexed():
     """cardio_entries.user_id — used in cardio list."""
     assert "user_id" in _indexed_columns("cardio_entries")
+
+
+def test_e2f9a3b7c1d5_upgrade_is_idempotent():
+    """upgrade() must not raise when indexes already exist (test DB has them from create_all)."""
+    migration_path = (
+        Path(__file__).parent.parent
+        / "alembic"
+        / "versions"
+        / "e2f9a3b7c1d5_add_indexes_on_logs_and_measurements.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "migration_e2f9a3b7c1d5", migration_path
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+
+    with engine.connect() as conn:
+        ctx = MigrationContext.configure(conn)
+        with Operations.context(ctx):
+            mod.upgrade()  # must not raise DuplicateObject / ProgrammingError


### PR DESCRIPTION
op.create_index() calls in the upgrade() function had no if_not_exists=True flag. Applied to a database where Base.metadata.create_all() had already run (any test DB or dev environment set up via the ORM rather than migrations), the migration raises DuplicateTable and fails. The same gap existed in downgrade() — op.drop_index() without if_exists=True would fail if the index was already absent.

Added if_not_exists=True to all five create_index calls and if_exists=True to all five drop_index calls. Added test_e2f9a3b7c1d5_upgrade_is_idempotent to test_indexes.py which loads the migration module and calls upgrade() against the test DB (which already has the indexes from create_all) — this was RED before the fix and GREEN after.

Closes #231