### PR TITLE
fix: replace falsy all() guard with is-not-None check in BIA formulae…

### DIFF
--- a/backend/routers/measurements.py
+++ b/backend/routers/measurements.py
@@ -77,9 +77,10 @@ class MeasurementOut(_MeasurementFields):
     recorded_at: datetime
 
 
-def _apply_formulae(measurement: BodyMeasurement, age: int, sex: int) -> None:
+def _apply_formulae(measurement: BodyMeasurement, age: int | None, sex: int) -> None:
     """If all required inputs are present, calculate and fill derived fields."""
-    height = measurement.height_cm or float(os.getenv("SCALE_HEIGHT_CM", "0"))
+    _env_h = float(os.getenv("SCALE_HEIGHT_CM", "0"))
+    height: float | None = measurement.height_cm or (_env_h or None)
 
     required = [
         age,
@@ -97,12 +98,12 @@ def _apply_formulae(measurement: BodyMeasurement, age: int, sex: int) -> None:
         measurement.ll_z100,
         measurement.trunk_z100,
     ]
-    if not all(required):
+    if not all(x is not None for x in required):
         return
 
     profile = UserProfile(
-        age=age,
-        height_cm=float(height),
+        age=cast(int, age),
+        height_cm=cast(float, height),
         sex=sex,
         weight_kg=cast(float, measurement.weight_kg),
     )
@@ -141,13 +142,14 @@ def log_measurement(
     if measurement.height_cm is None and current_user.height_cm:
         measurement.height_cm = current_user.height_cm
 
-    # Age: request → profile birth_year → env
+    # Age: request → profile birth_year → env (0 means not configured → None)
+    age: int | None
     if age_from_request:
         age = age_from_request
     elif current_user.birth_year:
         age = datetime.now(timezone.utc).year - current_user.birth_year
     else:
-        age = int(os.getenv("SCALE_AGE", "0"))
+        age = int(os.getenv("SCALE_AGE", "0")) or None
 
     # Sex: request → profile sex → env
     if sex_from_request is not None:

--- a/backend/tests/test_measurements.py
+++ b/backend/tests/test_measurements.py
@@ -139,3 +139,40 @@ def test_bia_formulae_skipped_when_inputs_incomplete(client: TestClient):
     data = resp.json()
     assert data["bmi"] is None
     assert data["fat_mass_kg"] is None
+
+
+def test_bia_formulae_run_when_body_fat_pct_is_zero(client: TestClient):
+    """body_fat_pct=0.0 is falsy but present — formulas must still run.
+
+    all(required) treats 0.0 as absent and skips all formulae, so bmi is
+    never computed even though height, weight, age, and all impedance values
+    are provided.  The correct guard is all(x is not None for x in required).
+    """
+    token = _token(client)
+    payload = {
+        "weight_kg": 80.0,
+        "height_cm": 175.0,
+        "body_fat_pct": 0.0,
+        "user_age": 35,
+        "user_sex": 1,
+        "ra_z20": 312.5,
+        "la_z20": 308.0,
+        "rl_z20": 210.0,
+        "ll_z20": 208.5,
+        "trunk_z20": 42.0,
+        "ra_z100": 290.0,
+        "la_z100": 287.0,
+        "rl_z100": 195.0,
+        "ll_z100": 193.0,
+        "trunk_z100": 38.0,
+    }
+    resp = client.post(
+        "/api/measurements",
+        json=payload,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["bmi"] is not None, "bmi must be computed even when body_fat_pct=0.0"
+    expected_bmi = round(80.0 / (1.75**2), 1)
+    assert abs(data["bmi"] - expected_bmi) < 0.5

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"


### PR DESCRIPTION
… (#220)

Python's all() treats 0.0 as falsy. When a smart-scale measurement includes body_fat_pct=0.0 (or any other numeric field that happens to be zero), the guard in _apply_formulae() short-circuits and silently skips all formula calculations, leaving bmi, fat_mass_kg, and the rest as None even though every required input is present.  The same issue affects age when SCALE_AGE is unset (defaults to int("0") = 0) and height when SCALE_HEIGHT_CM is unset (defaults to 0.0); both are now converted to None at their origin so the is-not-None guard is the only place that decides whether to skip.

Changed the guard to all(x is not None for x in required) so that genuinely-zero numeric values never suppress formula execution.  Height derivation now uses `_env_h or None` to convert the "not configured" sentinel (0.0) to an explicit None rather than relying on all() to catch it.  Age derivation uses the same `or None` pattern. _apply_formulae() signature updated to int | None to reflect that age may be absent.  Both call sites use cast() so mypy sees non-None types after the guard.

The new test posts a full BIA payload with body_fat_pct=0.0 and asserts that bmi is computed correctly (≈26.1).  The existing tests for complete payloads (bmi must appear) and incomplete payloads (bmi must be None) both continue to pass.

Closes #220