### PR TITLE
feat: invalidate JWT on password change via token_version (#226)

### DIFF
--- a/backend/alembic/versions/i5j7k9l1m3n4_add_token_version_to_users.py
+++ b/backend/alembic/versions/i5j7k9l1m3n4_add_token_version_to_users.py
@@ -1,0 +1,39 @@
+"""add token_version to users
+
+Revision ID: i5j7k9l1m3n4
+Revises: h4i6j8k0l2m3
+Create Date: 2026-07-12
+
+Adds token_version (integer, default 1) to the users table so that
+JWTs can be invalidated server-side without waiting for expiry.
+
+When a user changes their password, token_version is incremented.
+The JWT encodes the version at issue time; get_current_user rejects
+any token whose version does not match the current DB value.
+"""
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "i5j7k9l1m3n4"
+down_revision: Union[str, None] = "h4i6j8k0l2m3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "token_version",
+            sa.Integer(),
+            nullable=False,
+            server_default="1",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "token_version")

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -25,12 +25,12 @@ def verify_password(plain: str, hashed: str) -> bool:
 bearer = HTTPBearer()
 
 
-def create_access_token(user_id: int) -> str:
+def create_access_token(user_id: int, token_version: int) -> str:
     expire = datetime.now(timezone.utc) + timedelta(
         days=int(os.getenv("JWT_EXPIRE_DAYS", "7"))
     )
     return jwt.encode(
-        {"sub": str(user_id), "exp": expire},
+        {"sub": str(user_id), "ver": token_version, "exp": expire},
         os.getenv("SECRET_KEY"),
         algorithm=ALGORITHM,
     )
@@ -58,5 +58,10 @@ def get_current_user(
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="User not found or inactive",
+        )
+    if payload.get("ver") != user.token_version:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token has been invalidated",
         )
     return user

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -17,6 +17,7 @@ class User(Base):
     birth_year: Mapped[int | None] = mapped_column(Integer)
     sex: Mapped[str | None] = mapped_column(String)  # 'male' | 'female' | 'other'
     height_cm: Mapped[float | None] = mapped_column(Float)
+    token_version: Mapped[int] = mapped_column(Integer, default=1, nullable=False)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     is_admin: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -70,7 +70,7 @@ def register(body: RegisterRequest, db: Session = Depends(get_db)):
     db.add(user)
     db.commit()
     db.refresh(user)
-    return TokenResponse(access_token=create_access_token(user.id))
+    return TokenResponse(access_token=create_access_token(user.id, user.token_version))
 
 
 class ChangePasswordRequest(BaseModel):
@@ -90,6 +90,7 @@ def change_password(
             detail="Current password is incorrect",
         )
     current_user.hashed_password = hash_password(body.new_password)
+    current_user.token_version += 1
     db.commit()
     return {"detail": "Password updated"}
 
@@ -106,4 +107,4 @@ def login(request: Request, body: LoginRequest, db: Session = Depends(get_db)):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail="Account disabled"
         )
-    return TokenResponse(access_token=create_access_token(user.id))
+    return TokenResponse(access_token=create_access_token(user.id, user.token_version))

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -339,3 +339,35 @@ def test_active_account_wrong_password_still_401(client: TestClient):
     )
     assert resp.status_code == 401
     assert resp.json()["detail"] == "Invalid credentials"
+
+
+# ── JWT invalidation on credential change (#226) ─────────────────────────────
+
+
+def test_token_invalidated_after_password_change(client: TestClient):
+    """Token issued before a password change must be rejected after the change.
+
+    Without token_version, the old JWT stays valid until expiry because the
+    server has no way to tell the token is stale.  After the fix, change_password
+    bumps token_version; the old JWT carries the previous version and is rejected.
+    """
+    _make_user("stale_pw_user", "pass1234")
+    old_headers = _login(client, "stale_pw_user", "pass1234")
+    client.post(
+        "/api/auth/change-password",
+        json={"current_password": "pass1234", "new_password": "newpass5678"},
+        headers=old_headers,
+    )
+    assert client.get("/api/profile", headers=old_headers).status_code == 401
+
+
+def test_token_invalidated_after_gdpr_erase(client: TestClient):
+    """Token issued before GDPR self-erase must be rejected after deletion.
+
+    The user row is gone so get_current_user returns 401.  This is a regression
+    guard to ensure that behaviour is never silently removed.
+    """
+    _make_user("erase_token_user", "pass1234")
+    old_headers = _login(client, "erase_token_user", "pass1234")
+    client.delete("/api/gdpr/erase", headers=old_headers)
+    assert client.get("/api/profile", headers=old_headers).status_code == 401


### PR DESCRIPTION
Before this change, a JWT remained valid until its 7-day expiry even after the account's password was changed.  An attacker who captured a token (or a user who changed their password on a shared device) had no server-side way to invalidate outstanding sessions.

Added a token_version integer column (default 1, server_default="1" for existing rows) to the users table.  create_access_token now embeds the version as the "ver" claim; get_current_user rejects any token whose "ver" doesn't match the current DB value.  change_password increments token_version immediately after updating the hash, so every pre-change token is rejected on next use.  GDPR self-erase was already safe because the user row is deleted and db.get returns None.

Migration i5j7k9l1m3n4 adds the column.  Tests confirm: old token returns 401 after password change; old token returns 401 after self-erase (regression guard).

Closes #226